### PR TITLE
feat: support tensor reduction (ref. tensor_buffer.dart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-01-04
+
+### Added
+
+- Reduction operations for `TensorBuffer`:
+  - `sum()` - Returns the sum of all elements
+  - `mean()` - Returns the arithmetic mean of all elements
+  - `min()` - Returns the minimum value
+  - `max()` - Returns the maximum value
+- Axis-wise reduction operations:
+  - `sumAxis(int axis, {bool keepDims})` - Sum along a specific axis
+  - `meanAxis(int axis, {bool keepDims})` - Mean along a specific axis
+  - `minAxis(int axis, {bool keepDims})` - Min along a specific axis
+  - `maxAxis(int axis, {bool keepDims})` - Max along a specific axis
+- Support for negative axis indexing in axis-wise operations
+- Comprehensive test coverage for all reduction operations (49 tests)
+
 ## [0.1.3] - 2026-01-03
 
 ### Added

--- a/lib/src/core/tensor_buffer.dart
+++ b/lib/src/core/tensor_buffer.dart
@@ -451,6 +451,306 @@ class TensorBuffer {
     }
   }
 
+  // ============================================================
+  // Reduction Operations
+  // ============================================================
+
+  /// Returns the sum of all elements in this tensor.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([1, 2, 3, 4]),
+  ///   [2, 2],
+  /// );
+  /// print(tensor.sum()); // 10.0
+  /// ```
+  double sum() {
+    double result = 0;
+    final indices = List<int>.filled(rank, 0);
+
+    for (int i = 0; i < numel; i++) {
+      int offset = storageOffset;
+      for (int d = 0; d < rank; d++) {
+        offset += indices[d] * strides[d];
+      }
+      result += storage.getAsDouble(offset);
+      _incrementIndices(indices);
+    }
+
+    return result;
+  }
+
+  /// Returns the arithmetic mean of all elements in this tensor.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([1, 2, 3, 4]),
+  ///   [2, 2],
+  /// );
+  /// print(tensor.mean()); // 2.5
+  /// ```
+  double mean() => sum() / numel;
+
+  /// Returns the minimum value among all elements in this tensor.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5]),
+  ///   [5],
+  /// );
+  /// print(tensor.min()); // 1.0
+  /// ```
+  double min() {
+    double result = double.infinity;
+    final indices = List<int>.filled(rank, 0);
+
+    for (int i = 0; i < numel; i++) {
+      int offset = storageOffset;
+      for (int d = 0; d < rank; d++) {
+        offset += indices[d] * strides[d];
+      }
+      final value = storage.getAsDouble(offset);
+      if (value < result) result = value;
+      _incrementIndices(indices);
+    }
+
+    return result;
+  }
+
+  /// Returns the maximum value among all elements in this tensor.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5]),
+  ///   [5],
+  /// );
+  /// print(tensor.max()); // 5.0
+  /// ```
+  double max() {
+    double result = double.negativeInfinity;
+    final indices = List<int>.filled(rank, 0);
+
+    for (int i = 0; i < numel; i++) {
+      int offset = storageOffset;
+      for (int d = 0; d < rank; d++) {
+        offset += indices[d] * strides[d];
+      }
+      final value = storage.getAsDouble(offset);
+      if (value > result) result = value;
+      _incrementIndices(indices);
+    }
+
+    return result;
+  }
+
+  /// Increments multi-dimensional indices in row-major order.
+  void _incrementIndices(List<int> indices) {
+    for (int d = rank - 1; d >= 0; d--) {
+      indices[d]++;
+      if (indices[d] < shape[d]) break;
+      indices[d] = 0;
+    }
+  }
+
+  // ============================================================
+  // Axis-wise Reduction Operations
+  // ============================================================
+
+  /// Returns a tensor with the sum of elements along the specified [axis].
+  ///
+  /// If [keepDims] is true, the reduced dimension is retained with size 1.
+  /// Otherwise, the reduced dimension is removed from the output shape.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([1, 2, 3, 4, 5, 6]),
+  ///   [2, 3],
+  /// );
+  /// // Sum along axis 0: [1+4, 2+5, 3+6] = [5, 7, 9]
+  /// final result = tensor.sumAxis(0);
+  /// print(result.shape); // [3]
+  /// print(result.toList()); // [5.0, 7.0, 9.0]
+  /// ```
+  TensorBuffer sumAxis(int axis, {bool keepDims = false}) {
+    return _reduceAxis(axis, keepDims: keepDims, reduce: _sumReduce);
+  }
+
+  /// Returns a tensor with the mean of elements along the specified [axis].
+  ///
+  /// If [keepDims] is true, the reduced dimension is retained with size 1.
+  /// Otherwise, the reduced dimension is removed from the output shape.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([1, 2, 3, 4, 5, 6]),
+  ///   [2, 3],
+  /// );
+  /// // Mean along axis 0: [(1+4)/2, (2+5)/2, (3+6)/2] = [2.5, 3.5, 4.5]
+  /// final result = tensor.meanAxis(0);
+  /// print(result.toList()); // [2.5, 3.5, 4.5]
+  /// ```
+  TensorBuffer meanAxis(int axis, {bool keepDims = false}) {
+    return _reduceAxis(axis, keepDims: keepDims, reduce: _meanReduce);
+  }
+
+  /// Returns a tensor with the minimum value along the specified [axis].
+  ///
+  /// If [keepDims] is true, the reduced dimension is retained with size 1.
+  /// Otherwise, the reduced dimension is removed from the output shape.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5, 9]),
+  ///   [2, 3],
+  /// );
+  /// // Min along axis 1: [min(3,1,4), min(1,5,9)] = [1, 1]
+  /// final result = tensor.minAxis(1);
+  /// print(result.toList()); // [1.0, 1.0]
+  /// ```
+  TensorBuffer minAxis(int axis, {bool keepDims = false}) {
+    return _reduceAxis(axis, keepDims: keepDims, reduce: _minReduce);
+  }
+
+  /// Returns a tensor with the maximum value along the specified [axis].
+  ///
+  /// If [keepDims] is true, the reduced dimension is retained with size 1.
+  /// Otherwise, the reduced dimension is removed from the output shape.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5, 9]),
+  ///   [2, 3],
+  /// );
+  /// // Max along axis 1: [max(3,1,4), max(1,5,9)] = [4, 9]
+  /// final result = tensor.maxAxis(1);
+  /// print(result.toList()); // [4.0, 9.0]
+  /// ```
+  TensorBuffer maxAxis(int axis, {bool keepDims = false}) {
+    return _reduceAxis(axis, keepDims: keepDims, reduce: _maxReduce);
+  }
+
+  /// Generic axis reduction implementation.
+  TensorBuffer _reduceAxis(
+    int axis, {
+    required bool keepDims,
+    required double Function(List<double>) reduce,
+  }) {
+    // Normalize negative axis
+    final normalizedAxis = axis < 0 ? rank + axis : axis;
+
+    if (normalizedAxis < 0 || normalizedAxis >= rank) {
+      throw RangeError.range(axis, -rank, rank - 1, 'axis');
+    }
+
+    // Compute output shape
+    final outputShape = <int>[];
+    for (int d = 0; d < rank; d++) {
+      if (d == normalizedAxis) {
+        if (keepDims) outputShape.add(1);
+      } else {
+        outputShape.add(shape[d]);
+      }
+    }
+
+    // Handle scalar result (1D tensor reduced without keepDims)
+    if (outputShape.isEmpty) {
+      final values = <double>[];
+      final indices = List<int>.filled(rank, 0);
+      for (int i = 0; i < numel; i++) {
+        int offset = storageOffset;
+        for (int d = 0; d < rank; d++) {
+          offset += indices[d] * strides[d];
+        }
+        values.add(storage.getAsDouble(offset));
+        _incrementIndices(indices);
+      }
+      final resultValue = reduce(values);
+      return TensorBuffer.fromFloat32List(
+        Float32List.fromList([resultValue]),
+        [1],
+      );
+    }
+
+    // Create output buffer
+    final outputNumel = outputShape.fold(1, (a, b) => a * b);
+    final outputData = Float32List(outputNumel);
+
+    // Compute reductions
+    final axisSize = shape[normalizedAxis];
+    final outputIndices = List<int>.filled(outputShape.length, 0);
+
+    for (int outIdx = 0; outIdx < outputNumel; outIdx++) {
+      // Collect values along the reduction axis
+      final values = <double>[];
+
+      for (int axisIdx = 0; axisIdx < axisSize; axisIdx++) {
+        // Build input indices from output indices
+        final inputIndices = <int>[];
+        int outDim = 0;
+        for (int d = 0; d < rank; d++) {
+          if (d == normalizedAxis) {
+            inputIndices.add(axisIdx);
+            if (keepDims) outDim++; // Skip the size-1 dimension in output
+          } else {
+            inputIndices.add(outputIndices[outDim]);
+            outDim++;
+          }
+        }
+
+        // Compute offset and get value
+        int offset = storageOffset;
+        for (int d = 0; d < rank; d++) {
+          offset += inputIndices[d] * strides[d];
+        }
+        values.add(storage.getAsDouble(offset));
+      }
+
+      // Apply reduction and store result
+      outputData[outIdx] = reduce(values);
+
+      // Increment output indices
+      for (int d = outputShape.length - 1; d >= 0; d--) {
+        outputIndices[d]++;
+        if (outputIndices[d] < outputShape[d]) break;
+        outputIndices[d] = 0;
+      }
+    }
+
+    return TensorBuffer.fromFloat32List(outputData, outputShape);
+  }
+
+  static double _sumReduce(List<double> values) {
+    double result = 0;
+    for (final v in values) {
+      result += v;
+    }
+    return result;
+  }
+
+  static double _meanReduce(List<double> values) {
+    return _sumReduce(values) / values.length;
+  }
+
+  static double _minReduce(List<double> values) {
+    double result = double.infinity;
+    for (final v in values) {
+      if (v < result) result = v;
+    }
+    return result;
+  }
+
+  static double _maxReduce(List<double> values) {
+    double result = double.negativeInfinity;
+    for (final v in values) {
+      if (v > result) result = v;
+    }
+    return result;
+  }
+
+  // ============================================================
+  // Data Extraction
+  // ============================================================
+
   /// Returns all elements as a [List<double>].
   ///
   /// This method iterates over all elements in logical order and returns them
@@ -474,12 +774,7 @@ class TensorBuffer {
         offset += indices[d] * strides[d];
       }
       result.add(storage.getAsDouble(offset));
-
-      for (int d = rank - 1; d >= 0; d--) {
-        indices[d]++;
-        if (indices[d] < shape[d]) break;
-        indices[d] = 0;
-      }
+      _incrementIndices(indices);
     }
 
     return result;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tensor_preprocessing
 description: >-
   High-performance tensor preprocessing library for Flutter/Dart.
   NumPy-like transforms pipeline for ONNX Runtime inference.
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/brody-0125/dart_tensor_preprocessing
 homepage: https://github.com/brody-0125/dart_tensor_preprocessing
 

--- a/test/reduction_ops_test.dart
+++ b/test/reduction_ops_test.dart
@@ -1,0 +1,502 @@
+// Reduction operations tests
+//
+// Tests cover:
+// - sum(), mean(), min(), max() for various tensor shapes
+// - Different data types (float32, int32, uint8)
+// - Non-contiguous tensors (transposed)
+// - Edge cases (single element, large tensors)
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Reduction Operations', () {
+    group('sum', () {
+      test('1D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5]),
+          [5],
+        );
+        expect(tensor.sum(), equals(15.0));
+      });
+
+      test('2D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        expect(tensor.sum(), equals(21.0));
+      });
+
+      test('3D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8]),
+          [2, 2, 2],
+        );
+        expect(tensor.sum(), equals(36.0));
+      });
+
+      test('single element', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([42]),
+          [1],
+        );
+        expect(tensor.sum(), equals(42.0));
+      });
+
+      test('zeros tensor', () {
+        final tensor = TensorBuffer.zeros([3, 3]);
+        expect(tensor.sum(), equals(0.0));
+      });
+
+      test('ones tensor', () {
+        final tensor = TensorBuffer.ones([2, 3, 4]);
+        expect(tensor.sum(), equals(24.0));
+      });
+
+      test('non-contiguous (transposed) tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        final transposed = tensor.transpose([1, 0]);
+        expect(transposed.sum(), equals(21.0));
+      });
+
+      test('uint8 tensor', () {
+        final tensor = TensorBuffer.fromUint8List(
+          Uint8List.fromList([10, 20, 30, 40]),
+          [4],
+        );
+        expect(tensor.sum(), equals(100.0));
+      });
+    });
+
+    group('mean', () {
+      test('1D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5]),
+          [5],
+        );
+        expect(tensor.mean(), equals(3.0));
+      });
+
+      test('2D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        expect(tensor.mean(), equals(3.5));
+      });
+
+      test('single element', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([42]),
+          [1],
+        );
+        expect(tensor.mean(), equals(42.0));
+      });
+
+      test('non-contiguous (transposed) tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        final transposed = tensor.transpose([1, 0]);
+        expect(transposed.mean(), equals(3.5));
+      });
+    });
+
+    group('min', () {
+      test('1D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9, 2, 6]),
+          [8],
+        );
+        expect(tensor.min(), equals(1.0));
+      });
+
+      test('2D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([5, 2, 8, 1, 9, 3]),
+          [2, 3],
+        );
+        expect(tensor.min(), equals(1.0));
+      });
+
+      test('single element', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([42]),
+          [1],
+        );
+        expect(tensor.min(), equals(42.0));
+      });
+
+      test('negative values', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, -5, 3, -2, 4]),
+          [5],
+        );
+        expect(tensor.min(), equals(-5.0));
+      });
+
+      test('non-contiguous (transposed) tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([5, 2, 8, 1, 9, 3]),
+          [2, 3],
+        );
+        final transposed = tensor.transpose([1, 0]);
+        expect(transposed.min(), equals(1.0));
+      });
+
+      test('uint8 tensor', () {
+        final tensor = TensorBuffer.fromUint8List(
+          Uint8List.fromList([50, 10, 30, 20]),
+          [4],
+        );
+        expect(tensor.min(), equals(10.0));
+      });
+    });
+
+    group('max', () {
+      test('1D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9, 2, 6]),
+          [8],
+        );
+        expect(tensor.max(), equals(9.0));
+      });
+
+      test('2D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([5, 2, 8, 1, 9, 3]),
+          [2, 3],
+        );
+        expect(tensor.max(), equals(9.0));
+      });
+
+      test('single element', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([42]),
+          [1],
+        );
+        expect(tensor.max(), equals(42.0));
+      });
+
+      test('negative values', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([-1, -5, -3, -2, -4]),
+          [5],
+        );
+        expect(tensor.max(), equals(-1.0));
+      });
+
+      test('non-contiguous (transposed) tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([5, 2, 8, 1, 9, 3]),
+          [2, 3],
+        );
+        final transposed = tensor.transpose([1, 0]);
+        expect(transposed.max(), equals(9.0));
+      });
+
+      test('uint8 tensor', () {
+        final tensor = TensorBuffer.fromUint8List(
+          Uint8List.fromList([50, 10, 30, 200]),
+          [4],
+        );
+        expect(tensor.max(), equals(200.0));
+      });
+    });
+
+    group('sumAxis', () {
+      test('2D tensor along axis 0', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        // [[1, 2, 3], [4, 5, 6]] -> [5, 7, 9]
+        final result = tensor.sumAxis(0);
+        expect(result.shape, equals([3]));
+        expect(result.toList(), equals([5.0, 7.0, 9.0]));
+      });
+
+      test('2D tensor along axis 1', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        // [[1, 2, 3], [4, 5, 6]] -> [6, 15]
+        final result = tensor.sumAxis(1);
+        expect(result.shape, equals([2]));
+        expect(result.toList(), equals([6.0, 15.0]));
+      });
+
+      test('3D tensor along axis 0', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8]),
+          [2, 2, 2],
+        );
+        // [[[1,2],[3,4]], [[5,6],[7,8]]] -> [[6,8],[10,12]]
+        final result = tensor.sumAxis(0);
+        expect(result.shape, equals([2, 2]));
+        expect(result.toList(), equals([6.0, 8.0, 10.0, 12.0]));
+      });
+
+      test('3D tensor along axis 1', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8]),
+          [2, 2, 2],
+        );
+        // [[[1,2],[3,4]], [[5,6],[7,8]]] -> [[4,6],[12,14]]
+        final result = tensor.sumAxis(1);
+        expect(result.shape, equals([2, 2]));
+        expect(result.toList(), equals([4.0, 6.0, 12.0, 14.0]));
+      });
+
+      test('3D tensor along axis 2', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8]),
+          [2, 2, 2],
+        );
+        // [[[1,2],[3,4]], [[5,6],[7,8]]] -> [[3,7],[11,15]]
+        final result = tensor.sumAxis(2);
+        expect(result.shape, equals([2, 2]));
+        expect(result.toList(), equals([3.0, 7.0, 11.0, 15.0]));
+      });
+
+      test('keepDims=true preserves dimension', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        final result = tensor.sumAxis(0, keepDims: true);
+        expect(result.shape, equals([1, 3]));
+        expect(result.toList(), equals([5.0, 7.0, 9.0]));
+      });
+
+      test('negative axis', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        // axis=-1 is same as axis=1
+        final result = tensor.sumAxis(-1);
+        expect(result.shape, equals([2]));
+        expect(result.toList(), equals([6.0, 15.0]));
+      });
+
+      test('1D tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5]),
+          [5],
+        );
+        final result = tensor.sumAxis(0);
+        expect(result.shape, equals([1]));
+        expect(result.toList(), equals([15.0]));
+      });
+
+      test('non-contiguous (transposed) tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        final transposed = tensor.transpose([1, 0]); // shape [3, 2]
+        // [[1, 4], [2, 5], [3, 6]] -> [5, 7, 9]
+        final result = transposed.sumAxis(1);
+        expect(result.shape, equals([3]));
+        expect(result.toList(), equals([5.0, 7.0, 9.0]));
+      });
+    });
+
+    group('meanAxis', () {
+      test('2D tensor along axis 0', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        // [[1, 2, 3], [4, 5, 6]] -> [2.5, 3.5, 4.5]
+        final result = tensor.meanAxis(0);
+        expect(result.shape, equals([3]));
+        expect(result.toList(), equals([2.5, 3.5, 4.5]));
+      });
+
+      test('2D tensor along axis 1', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        // [[1, 2, 3], [4, 5, 6]] -> [2.0, 5.0]
+        final result = tensor.meanAxis(1);
+        expect(result.shape, equals([2]));
+        expect(result.toList(), equals([2.0, 5.0]));
+      });
+
+      test('keepDims=true', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6]),
+          [2, 3],
+        );
+        final result = tensor.meanAxis(1, keepDims: true);
+        expect(result.shape, equals([2, 1]));
+        expect(result.toList(), equals([2.0, 5.0]));
+      });
+    });
+
+    group('minAxis', () {
+      test('2D tensor along axis 0', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9]),
+          [2, 3],
+        );
+        // [[3, 1, 4], [1, 5, 9]] -> [1, 1, 4]
+        final result = tensor.minAxis(0);
+        expect(result.shape, equals([3]));
+        expect(result.toList(), equals([1.0, 1.0, 4.0]));
+      });
+
+      test('2D tensor along axis 1', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9]),
+          [2, 3],
+        );
+        // [[3, 1, 4], [1, 5, 9]] -> [1, 1]
+        final result = tensor.minAxis(1);
+        expect(result.shape, equals([2]));
+        expect(result.toList(), equals([1.0, 1.0]));
+      });
+
+      test('with negative values', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, -2, 3, -4, 5, -6]),
+          [2, 3],
+        );
+        final result = tensor.minAxis(0);
+        expect(result.toList(), equals([-4.0, -2.0, -6.0]));
+      });
+
+      test('keepDims=true', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9]),
+          [2, 3],
+        );
+        final result = tensor.minAxis(0, keepDims: true);
+        expect(result.shape, equals([1, 3]));
+      });
+    });
+
+    group('maxAxis', () {
+      test('2D tensor along axis 0', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9]),
+          [2, 3],
+        );
+        // [[3, 1, 4], [1, 5, 9]] -> [3, 5, 9]
+        final result = tensor.maxAxis(0);
+        expect(result.shape, equals([3]));
+        expect(result.toList(), equals([3.0, 5.0, 9.0]));
+      });
+
+      test('2D tensor along axis 1', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9]),
+          [2, 3],
+        );
+        // [[3, 1, 4], [1, 5, 9]] -> [4, 9]
+        final result = tensor.maxAxis(1);
+        expect(result.shape, equals([2]));
+        expect(result.toList(), equals([4.0, 9.0]));
+      });
+
+      test('with negative values', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([-1, -2, -3, -4, -5, -6]),
+          [2, 3],
+        );
+        // [[-1, -2, -3], [-4, -5, -6]] -> [-1, -2, -3]
+        final result = tensor.maxAxis(0);
+        expect(result.toList(), equals([-1.0, -2.0, -3.0]));
+      });
+
+      test('keepDims=true', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([3, 1, 4, 1, 5, 9]),
+          [2, 3],
+        );
+        final result = tensor.maxAxis(1, keepDims: true);
+        expect(result.shape, equals([2, 1]));
+        expect(result.toList(), equals([4.0, 9.0]));
+      });
+    });
+
+    group('axis reduction edge cases', () {
+      test('invalid axis throws RangeError', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4]),
+          [2, 2],
+        );
+        expect(() => tensor.sumAxis(2), throwsRangeError);
+        expect(() => tensor.sumAxis(-3), throwsRangeError);
+      });
+
+      test('4D tensor reduction', () {
+        // Shape: [2, 2, 2, 2]
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList(List.generate(16, (i) => (i + 1).toDouble())),
+          [2, 2, 2, 2],
+        );
+
+        // Sum along axis 0
+        final result0 = tensor.sumAxis(0);
+        expect(result0.shape, equals([2, 2, 2]));
+
+        // Sum along last axis
+        final result3 = tensor.sumAxis(3);
+        expect(result3.shape, equals([2, 2, 2]));
+      });
+    });
+
+    group('combined operations', () {
+      test('sum, mean, min, max on same tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+          [2, 5],
+        );
+
+        expect(tensor.sum(), equals(55.0));
+        expect(tensor.mean(), equals(5.5));
+        expect(tensor.min(), equals(1.0));
+        expect(tensor.max(), equals(10.0));
+      });
+
+      test('operations on squeezed tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3]),
+          [1, 3, 1],
+        );
+        final squeezed = tensor.squeeze();
+
+        expect(squeezed.shape, equals([3]));
+        expect(squeezed.sum(), equals(6.0));
+        expect(squeezed.mean(), equals(2.0));
+        expect(squeezed.min(), equals(1.0));
+        expect(squeezed.max(), equals(3.0));
+      });
+
+      test('operations on unsqueezed tensor', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3]),
+          [3],
+        );
+        final unsqueezed = tensor.unsqueeze(0);
+
+        expect(unsqueezed.shape, equals([1, 3]));
+        expect(unsqueezed.sum(), equals(6.0));
+        expect(unsqueezed.mean(), equals(2.0));
+        expect(unsqueezed.min(), equals(1.0));
+        expect(unsqueezed.max(), equals(3.0));
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Reduction operations for TensorBuffer:
  - `sum()` - Returns the sum of all elements
  - `mean()` - Returns the arithmetic mean of all elements
  - `min()` - Returns the minimum value
  - `max()` - Returns the maximum value
- Axis-wise reduction operations:
  - `sumAxis(int axis, {bool keepDims})` - Sum along a specific axis
  - `meanAxis(int axis, {bool keepDims})` - Mean along a specific axis
  - `minAxis(int axis, {bool keepDims})` - Min along a specific axis
  - `maxAxis(int axis, {bool keepDims})` - Max along a specific axis