### PR TITLE
refactor: performance optimizations (copy, async, index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-01-09
+
+### Performance Optimizations
+
+- **Dtype-specialized loops**: Hot paths in transform operations now use dtype-specific code paths with direct `Float32List`/`Float64List` access, avoiding per-element switch overhead:
+  - `NormalizeOp._normalize3D()`, `NormalizeOp._normalize4D()`
+  - `ScaleOp._scale()`
+  - `ClipOp._clip()`
+  - `GaussianBlurOp._applySeparableBlur()`
+  - `ResizeOp._resizeNearest()`, `_resizeBilinear()`, `_resizeBicubic()`
+  - `CenterCropOp._crop3D()`, `_crop4D()`
+  - `concat()` with optimized axis=0 bulk copy
+
+- **Clone-Before-Modify optimization**: `ClipOp.apply()` now avoids double copy by checking `isContiguous` before deciding whether to `clone()` or `contiguous()`
+
+- **Isolate threshold**: `TensorPipeline.runAsync()` now accepts optional `isolateThreshold` parameter (default: 100,000 elements). Small tensors skip isolate overhead and run synchronously
+
+- **Buffer reuse**: `GaussianBlurOp` now pre-allocates and reuses temp buffer across channels, reducing allocations
+
+- **Concat linear copy**: `concat()` now uses pre-computed strides for linear index calculation instead of recursive index computation. Axis=0 concatenation of contiguous tensors uses bulk `setRange()` copy
+
+- **Loop unrolling**: `ResizeOp._resizeBicubic()` unrolls 4x4 kernel with pre-computed weights and indices
+
 ## [0.4.0] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tensor preprocessing library for Flutter/Dart. NumPy-like transforms pipeline fo
 
 ```yaml
 dependencies:
-  dart_tensor_preprocessing: ^0.4.0
+  dart_tensor_preprocessing: ^0.4.1
 ```
 
 ## Quick Start
@@ -62,6 +62,10 @@ final result = pipeline.run(input);
 
 // Async execution (runs in isolate)
 final result = await pipeline.runAsync(input);
+
+// Async with custom isolate threshold (default: 100,000 elements)
+// Small tensors skip isolate overhead and run synchronously
+final result = await pipeline.runAsync(input, isolateThreshold: 50000);
 ```
 
 ## Available Operations

--- a/lib/src/ops/augmentation_op.dart
+++ b/lib/src/ops/augmentation_op.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
+import 'dart:typed_data';
 
+import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
 import '../exceptions/tensor_exceptions.dart';
 import '../utils/index_utils.dart';
@@ -235,35 +237,67 @@ class GaussianBlurOp extends TransformOp with RequiresContiguous {
       final (c, h, w) = (inputShape[0], inputShape[1], inputShape[2]);
       final output = TensorBuffer.zeros([c, h, w], dtype: input.dtype);
 
-      for (int ch = 0; ch < c; ch++) {
-        // Horizontal pass
-        final temp = List<double>.filled(h * w, 0.0);
-        for (int row = 0; row < h; row++) {
-          for (int col = 0; col < w; col++) {
-            double sum = 0.0;
-            for (int k = 0; k < kernelSize; k++) {
-              final x = col + k - radius;
-              final xi = reflectIndex(x, w);
-              final inputIdx = ch * h * w + row * w + xi;
-              sum += input.storage.getAsDouble(inputIdx) * kernel[k];
-            }
-            temp[row * w + col] = sum;
-          }
-        }
+      // Pre-allocate temp buffer (reused across channels)
+      final temp = Float64List(h * w);
 
-        // Vertical pass
-        for (int row = 0; row < h; row++) {
-          for (int col = 0; col < w; col++) {
-            double sum = 0.0;
-            for (int k = 0; k < kernelSize; k++) {
-              final y = row + k - radius;
-              final yi = reflectIndex(y, h);
-              sum += temp[yi * w + col] * kernel[k];
+      // Dtype-specialized for hot path optimization
+      switch (input.dtype) {
+        case DType.float32:
+          final inList = input.storage.data as Float32List;
+          final outList = output.storage.data as Float32List;
+          for (int ch = 0; ch < c; ch++) {
+            final chOffset = ch * h * w;
+            // Horizontal pass
+            for (int row = 0; row < h; row++) {
+              for (int col = 0; col < w; col++) {
+                double sum = 0.0;
+                for (int k = 0; k < kernelSize; k++) {
+                  final xi = reflectIndex(col + k - radius, w);
+                  sum += inList[chOffset + row * w + xi] * kernel[k];
+                }
+                temp[row * w + col] = sum;
+              }
             }
-            final outputIdx = ch * h * w + row * w + col;
-            output.storage.setFromDouble(outputIdx, sum);
+            // Vertical pass
+            for (int row = 0; row < h; row++) {
+              for (int col = 0; col < w; col++) {
+                double sum = 0.0;
+                for (int k = 0; k < kernelSize; k++) {
+                  final yi = reflectIndex(row + k - radius, h);
+                  sum += temp[yi * w + col] * kernel[k];
+                }
+                outList[chOffset + row * w + col] = sum;
+              }
+            }
           }
-        }
+        default:
+          // Generic fallback
+          for (int ch = 0; ch < c; ch++) {
+            // Horizontal pass
+            for (int row = 0; row < h; row++) {
+              for (int col = 0; col < w; col++) {
+                double sum = 0.0;
+                for (int k = 0; k < kernelSize; k++) {
+                  final xi = reflectIndex(col + k - radius, w);
+                  final inputIdx = ch * h * w + row * w + xi;
+                  sum += input.storage.getAsDouble(inputIdx) * kernel[k];
+                }
+                temp[row * w + col] = sum;
+              }
+            }
+            // Vertical pass
+            for (int row = 0; row < h; row++) {
+              for (int col = 0; col < w; col++) {
+                double sum = 0.0;
+                for (int k = 0; k < kernelSize; k++) {
+                  final yi = reflectIndex(row + k - radius, h);
+                  sum += temp[yi * w + col] * kernel[k];
+                }
+                final outputIdx = ch * h * w + row * w + col;
+                output.storage.setFromDouble(outputIdx, sum);
+              }
+            }
+          }
       }
 
       return output;
@@ -273,37 +307,74 @@ class GaussianBlurOp extends TransformOp with RequiresContiguous {
           (inputShape[0], inputShape[1], inputShape[2], inputShape[3]);
       final output = TensorBuffer.zeros([n, c, h, w], dtype: input.dtype);
 
-      for (int batch = 0; batch < n; batch++) {
-        for (int ch = 0; ch < c; ch++) {
-          // Horizontal pass
-          final temp = List<double>.filled(h * w, 0.0);
-          for (int row = 0; row < h; row++) {
-            for (int col = 0; col < w; col++) {
-              double sum = 0.0;
-              for (int k = 0; k < kernelSize; k++) {
-                final x = col + k - radius;
-                final xi = reflectIndex(x, w);
-                final inputIdx = batch * c * h * w + ch * h * w + row * w + xi;
-                sum += input.storage.getAsDouble(inputIdx) * kernel[k];
-              }
-              temp[row * w + col] = sum;
-            }
-          }
+      // Pre-allocate temp buffer (reused across batches and channels)
+      final temp = Float64List(h * w);
 
-          // Vertical pass
-          for (int row = 0; row < h; row++) {
-            for (int col = 0; col < w; col++) {
-              double sum = 0.0;
-              for (int k = 0; k < kernelSize; k++) {
-                final y = row + k - radius;
-                final yi = reflectIndex(y, h);
-                sum += temp[yi * w + col] * kernel[k];
+      // Dtype-specialized for hot path optimization
+      switch (input.dtype) {
+        case DType.float32:
+          final inList = input.storage.data as Float32List;
+          final outList = output.storage.data as Float32List;
+          for (int batch = 0; batch < n; batch++) {
+            final batchOffset = batch * c * h * w;
+            for (int ch = 0; ch < c; ch++) {
+              final chOffset = batchOffset + ch * h * w;
+              // Horizontal pass
+              for (int row = 0; row < h; row++) {
+                for (int col = 0; col < w; col++) {
+                  double sum = 0.0;
+                  for (int k = 0; k < kernelSize; k++) {
+                    final xi = reflectIndex(col + k - radius, w);
+                    sum += inList[chOffset + row * w + xi] * kernel[k];
+                  }
+                  temp[row * w + col] = sum;
+                }
               }
-              final outputIdx = batch * c * h * w + ch * h * w + row * w + col;
-              output.storage.setFromDouble(outputIdx, sum);
+              // Vertical pass
+              for (int row = 0; row < h; row++) {
+                for (int col = 0; col < w; col++) {
+                  double sum = 0.0;
+                  for (int k = 0; k < kernelSize; k++) {
+                    final yi = reflectIndex(row + k - radius, h);
+                    sum += temp[yi * w + col] * kernel[k];
+                  }
+                  outList[chOffset + row * w + col] = sum;
+                }
+              }
             }
           }
-        }
+        default:
+          // Generic fallback
+          for (int batch = 0; batch < n; batch++) {
+            for (int ch = 0; ch < c; ch++) {
+              // Horizontal pass
+              for (int row = 0; row < h; row++) {
+                for (int col = 0; col < w; col++) {
+                  double sum = 0.0;
+                  for (int k = 0; k < kernelSize; k++) {
+                    final xi = reflectIndex(col + k - radius, w);
+                    final inputIdx =
+                        batch * c * h * w + ch * h * w + row * w + xi;
+                    sum += input.storage.getAsDouble(inputIdx) * kernel[k];
+                  }
+                  temp[row * w + col] = sum;
+                }
+              }
+              // Vertical pass
+              for (int row = 0; row < h; row++) {
+                for (int col = 0; col < w; col++) {
+                  double sum = 0.0;
+                  for (int k = 0; k < kernelSize; k++) {
+                    final yi = reflectIndex(row + k - radius, h);
+                    sum += temp[yi * w + col] * kernel[k];
+                  }
+                  final outputIdx =
+                      batch * c * h * w + ch * h * w + row * w + col;
+                  output.storage.setFromDouble(outputIdx, sum);
+                }
+              }
+            }
+          }
       }
 
       return output;

--- a/lib/src/ops/clip_op.dart
+++ b/lib/src/ops/clip_op.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+
+import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
 import '../exceptions/tensor_exceptions.dart';
 import 'transform_op.dart';
@@ -38,8 +41,14 @@ class ClipOp extends TransformOp with InPlaceTransform, RequiresContiguous {
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-    final output = contiguous.clone();
+    // Optimization: if input is already contiguous, clone() once.
+    // If not contiguous, contiguous() creates a copy, so no need to clone again.
+    final TensorBuffer output;
+    if (input.isContiguous) {
+      output = input.clone();
+    } else {
+      output = input.contiguous();
+    }
     _clip(output);
     return output;
   }
@@ -54,10 +63,26 @@ class ClipOp extends TransformOp with InPlaceTransform, RequiresContiguous {
 
   void _clip(TensorBuffer tensor) {
     final numel = tensor.numel;
-    for (int i = 0; i < numel; i++) {
-      final value = tensor.storage.getAsDouble(i);
-      final clampedValue = value.clamp(min, max);
-      tensor.storage.setFromDouble(i, clampedValue);
+    final data = tensor.storage.data;
+
+    // Dtype-specialized loop to avoid per-element switch overhead
+    switch (tensor.dtype) {
+      case DType.float32:
+        final list = data as Float32List;
+        for (int i = 0; i < numel; i++) {
+          list[i] = list[i].clamp(min, max);
+        }
+      case DType.float64:
+        final list = data as Float64List;
+        for (int i = 0; i < numel; i++) {
+          list[i] = list[i].clamp(min, max);
+        }
+      default:
+        // Fallback for integer types
+        for (int i = 0; i < numel; i++) {
+          final value = tensor.storage.getAsDouble(i);
+          tensor.storage.setFromDouble(i, value.clamp(min, max));
+        }
     }
   }
 

--- a/lib/src/ops/concat_op.dart
+++ b/lib/src/ops/concat_op.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+
+import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
 import '../exceptions/tensor_exceptions.dart';
 
@@ -78,17 +81,57 @@ TensorBuffer concat(List<TensorBuffer> tensors, {int axis = 0}) {
   // Create output tensor
   final output = TensorBuffer.zeros(outputShape, dtype: firstTensor.dtype);
 
-  // Copy data from each tensor
-  int outputOffset = 0;
-  for (final tensor in tensors) {
-    final tensorAxisSize = tensor.shape[normalizedAxis];
-    _copyTensorToConcat(tensor, output, outputOffset, normalizedAxis);
-    outputOffset += tensorAxisSize;
+  // Optimized copy using linear indexing
+  // For axis=0 and contiguous tensors, use bulk copy
+  if (normalizedAxis == 0 && tensors.every((t) => t.isContiguous)) {
+    _copyContiguousAxis0(tensors, output);
+  } else {
+    // General case: use strided copy
+    int axisOffset = 0;
+    for (final tensor in tensors) {
+      final contiguous = tensor.isContiguous ? tensor : tensor.contiguous();
+      final tensorAxisSize = contiguous.shape[normalizedAxis];
+      _copyTensorToConcat(contiguous, output, axisOffset, normalizedAxis);
+      axisOffset += tensorAxisSize;
+    }
   }
 
   return output;
 }
 
+/// Optimized bulk copy for axis=0 concatenation of contiguous tensors.
+void _copyContiguousAxis0(List<TensorBuffer> tensors, TensorBuffer output) {
+  switch (output.dtype) {
+    case DType.float32:
+      final outList = output.storage.data as Float32List;
+      int offset = 0;
+      for (final tensor in tensors) {
+        final inList = tensor.storage.data as Float32List;
+        outList.setRange(offset, offset + tensor.numel, inList);
+        offset += tensor.numel;
+      }
+    case DType.float64:
+      final outList = output.storage.data as Float64List;
+      int offset = 0;
+      for (final tensor in tensors) {
+        final inList = tensor.storage.data as Float64List;
+        outList.setRange(offset, offset + tensor.numel, inList);
+        offset += tensor.numel;
+      }
+    default:
+      // Generic fallback using setRange for typed lists
+      int offset = 0;
+      for (final tensor in tensors) {
+        for (int i = 0; i < tensor.numel; i++) {
+          final value = tensor.storage.getAsDouble(i);
+          output.storage.setFromDouble(offset + i, value);
+        }
+        offset += tensor.numel;
+      }
+  }
+}
+
+/// Copy tensor data using linear stride calculation instead of recursion.
 void _copyTensorToConcat(
   TensorBuffer source,
   TensorBuffer destination,
@@ -99,42 +142,51 @@ void _copyTensorToConcat(
   final destShape = destination.shape;
   final rank = sourceShape.length;
 
-  // Recursive copy with proper axis handling
-  void copyRecursive(List<int> sourceIndices, List<int> destIndices, int dim) {
-    if (dim == rank) {
-      // Calculate linear indices
-      int srcIdx = 0;
-      int srcStride = 1;
-      for (int i = rank - 1; i >= 0; i--) {
-        srcIdx += sourceIndices[i] * srcStride;
-        srcStride *= sourceShape[i];
-      }
-
-      int destIdx = 0;
-      int destStride = 1;
-      for (int i = rank - 1; i >= 0; i--) {
-        destIdx += destIndices[i] * destStride;
-        destStride *= destShape[i];
-      }
-
-      final value = source.storage.getAsDouble(srcIdx);
-      destination.storage.setFromDouble(destIdx, value);
-      return;
-    }
-
-    final dimSize = sourceShape[dim];
-    for (int i = 0; i < dimSize; i++) {
-      sourceIndices[dim] = i;
-      if (dim == concatAxis) {
-        destIndices[dim] = axisOffset + i;
-      } else {
-        destIndices[dim] = i;
-      }
-      copyRecursive(sourceIndices, destIndices, dim + 1);
-    }
+  // Pre-compute strides for both tensors
+  final srcStrides = List<int>.filled(rank, 1);
+  final destStrides = List<int>.filled(rank, 1);
+  for (int i = rank - 2; i >= 0; i--) {
+    srcStrides[i] = srcStrides[i + 1] * sourceShape[i + 1];
+    destStrides[i] = destStrides[i + 1] * destShape[i + 1];
   }
 
-  final sourceIndices = List<int>.filled(rank, 0);
-  final destIndices = List<int>.filled(rank, 0);
-  copyRecursive(sourceIndices, destIndices, 0);
+  // Compute total number of elements and iterate linearly
+  final numel = source.numel;
+
+  // Dtype-specialized for hot path optimization
+  switch (source.dtype) {
+    case DType.float32:
+      final srcList = source.storage.data as Float32List;
+      final destList = destination.storage.data as Float32List;
+
+      for (int srcIdx = 0; srcIdx < numel; srcIdx++) {
+        // Convert source linear index to multi-dimensional index
+        // then to destination linear index
+        int remaining = srcIdx;
+        int destIdx = 0;
+        for (int dim = 0; dim < rank; dim++) {
+          final coord = remaining ~/ srcStrides[dim];
+          remaining = remaining % srcStrides[dim];
+          // Adjust coordinate for concat axis
+          final destCoord = (dim == concatAxis) ? coord + axisOffset : coord;
+          destIdx += destCoord * destStrides[dim];
+        }
+        destList[destIdx] = srcList[srcIdx];
+      }
+
+    default:
+      // Generic fallback
+      for (int srcIdx = 0; srcIdx < numel; srcIdx++) {
+        int remaining = srcIdx;
+        int destIdx = 0;
+        for (int dim = 0; dim < rank; dim++) {
+          final coord = remaining ~/ srcStrides[dim];
+          remaining = remaining % srcStrides[dim];
+          final destCoord = (dim == concatAxis) ? coord + axisOffset : coord;
+          destIdx += destCoord * destStrides[dim];
+        }
+        final value = source.storage.getAsDouble(srcIdx);
+        destination.storage.setFromDouble(destIdx, value);
+      }
+  }
 }

--- a/lib/src/ops/normalize_op.dart
+++ b/lib/src/ops/normalize_op.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+
+import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
 import '../exceptions/tensor_exceptions.dart';
 import 'transform_op.dart';
@@ -121,17 +124,44 @@ class NormalizeOp extends TransformOp
     final h = tensor.shape[1];
     final w = tensor.shape[2];
     final channelSize = h * w;
+    final data = tensor.storage.data;
 
-    for (int ch = 0; ch < c; ch++) {
-      final offset = ch * channelSize;
-      final m = mean[ch];
-      final s = std[ch];
-
-      for (int i = 0; i < channelSize; i++) {
-        final idx = offset + i;
-        final value = tensor.storage.getAsDouble(idx);
-        tensor.storage.setFromDouble(idx, (value - m) / s);
-      }
+    // Dtype-specialized loop to avoid per-element switch overhead
+    switch (tensor.dtype) {
+      case DType.float32:
+        final list = data as Float32List;
+        for (int ch = 0; ch < c; ch++) {
+          final offset = ch * channelSize;
+          final m = mean[ch];
+          final s = std[ch];
+          for (int i = 0; i < channelSize; i++) {
+            final idx = offset + i;
+            list[idx] = (list[idx] - m) / s;
+          }
+        }
+      case DType.float64:
+        final list = data as Float64List;
+        for (int ch = 0; ch < c; ch++) {
+          final offset = ch * channelSize;
+          final m = mean[ch];
+          final s = std[ch];
+          for (int i = 0; i < channelSize; i++) {
+            final idx = offset + i;
+            list[idx] = (list[idx] - m) / s;
+          }
+        }
+      default:
+        // Fallback for integer types (less common for normalization)
+        for (int ch = 0; ch < c; ch++) {
+          final offset = ch * channelSize;
+          final m = mean[ch];
+          final s = std[ch];
+          for (int i = 0; i < channelSize; i++) {
+            final idx = offset + i;
+            final value = tensor.storage.getAsDouble(idx);
+            tensor.storage.setFromDouble(idx, (value - m) / s);
+          }
+        }
     }
   }
 
@@ -142,20 +172,53 @@ class NormalizeOp extends TransformOp
     final w = tensor.shape[3];
     final channelSize = h * w;
     final batchSize = c * channelSize;
+    final data = tensor.storage.data;
 
-    for (int batch = 0; batch < n; batch++) {
-      final batchOffset = batch * batchSize;
-      for (int ch = 0; ch < c; ch++) {
-        final offset = batchOffset + ch * channelSize;
-        final m = mean[ch];
-        final s = std[ch];
-
-        for (int i = 0; i < channelSize; i++) {
-          final idx = offset + i;
-          final value = tensor.storage.getAsDouble(idx);
-          tensor.storage.setFromDouble(idx, (value - m) / s);
+    // Dtype-specialized loop to avoid per-element switch overhead
+    switch (tensor.dtype) {
+      case DType.float32:
+        final list = data as Float32List;
+        for (int batch = 0; batch < n; batch++) {
+          final batchOffset = batch * batchSize;
+          for (int ch = 0; ch < c; ch++) {
+            final offset = batchOffset + ch * channelSize;
+            final m = mean[ch];
+            final s = std[ch];
+            for (int i = 0; i < channelSize; i++) {
+              final idx = offset + i;
+              list[idx] = (list[idx] - m) / s;
+            }
+          }
         }
-      }
+      case DType.float64:
+        final list = data as Float64List;
+        for (int batch = 0; batch < n; batch++) {
+          final batchOffset = batch * batchSize;
+          for (int ch = 0; ch < c; ch++) {
+            final offset = batchOffset + ch * channelSize;
+            final m = mean[ch];
+            final s = std[ch];
+            for (int i = 0; i < channelSize; i++) {
+              final idx = offset + i;
+              list[idx] = (list[idx] - m) / s;
+            }
+          }
+        }
+      default:
+        // Fallback for integer types
+        for (int batch = 0; batch < n; batch++) {
+          final batchOffset = batch * batchSize;
+          for (int ch = 0; ch < c; ch++) {
+            final offset = batchOffset + ch * channelSize;
+            final m = mean[ch];
+            final s = std[ch];
+            for (int i = 0; i < channelSize; i++) {
+              final idx = offset + i;
+              final value = tensor.storage.getAsDouble(idx);
+              tensor.storage.setFromDouble(idx, (value - m) / s);
+            }
+          }
+        }
     }
   }
 
@@ -211,9 +274,26 @@ class ScaleOp extends TransformOp with InPlaceTransform, RequiresContiguous {
 
   void _scale(TensorBuffer tensor) {
     final numel = tensor.numel;
-    for (int i = 0; i < numel; i++) {
-      final value = tensor.storage.getAsDouble(i);
-      tensor.storage.setFromDouble(i, (value - offset) / scale);
+    final data = tensor.storage.data;
+
+    // Dtype-specialized loop to avoid per-element switch overhead
+    switch (tensor.dtype) {
+      case DType.float32:
+        final list = data as Float32List;
+        for (int i = 0; i < numel; i++) {
+          list[i] = (list[i] - offset) / scale;
+        }
+      case DType.float64:
+        final list = data as Float64List;
+        for (int i = 0; i < numel; i++) {
+          list[i] = (list[i] - offset) / scale;
+        }
+      default:
+        // Fallback for integer types
+        for (int i = 0; i < numel; i++) {
+          final value = tensor.storage.getAsDouble(i);
+          tensor.storage.setFromDouble(i, (value - offset) / scale);
+        }
     }
   }
 

--- a/lib/src/ops/resize_op.dart
+++ b/lib/src/ops/resize_op.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
+import 'dart:typed_data';
 
+import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
 import '../exceptions/tensor_exceptions.dart';
 import 'transform_op.dart';
@@ -186,13 +188,31 @@ class ResizeOp extends TransformOp with RequiresContiguous {
     final scaleY = srcH / height;
     final scaleX = srcW / width;
 
-    for (int y = 0; y < height; y++) {
-      final srcY = (y * scaleY).floor().clamp(0, srcH - 1);
-      for (int x = 0; x < width; x++) {
-        final srcX = (x * scaleX).floor().clamp(0, srcW - 1);
-        final value = input.storage.getAsDouble(srcOffset + srcY * srcW + srcX);
-        output.storage.setFromDouble(dstOffset + y * width + x, value);
-      }
+    // Dtype-specialized for hot path optimization
+    switch (input.dtype) {
+      case DType.float32:
+        final inList = input.storage.data as Float32List;
+        final outList = output.storage.data as Float32List;
+        for (int y = 0; y < height; y++) {
+          final srcY = (y * scaleY).floor().clamp(0, srcH - 1);
+          final srcRowOffset = srcOffset + srcY * srcW;
+          final dstRowOffset = dstOffset + y * width;
+          for (int x = 0; x < width; x++) {
+            final srcX = (x * scaleX).floor().clamp(0, srcW - 1);
+            outList[dstRowOffset + x] = inList[srcRowOffset + srcX];
+          }
+        }
+      default:
+        // Generic fallback
+        for (int y = 0; y < height; y++) {
+          final srcY = (y * scaleY).floor().clamp(0, srcH - 1);
+          for (int x = 0; x < width; x++) {
+            final srcX = (x * scaleX).floor().clamp(0, srcW - 1);
+            final value =
+                input.storage.getAsDouble(srcOffset + srcY * srcW + srcX);
+            output.storage.setFromDouble(dstOffset + y * width + x, value);
+          }
+        }
     }
   }
 
@@ -209,32 +229,71 @@ class ResizeOp extends TransformOp with RequiresContiguous {
     final scaleX =
         alignCorners && width > 1 ? (srcW - 1) / (width - 1) : srcW / width;
 
-    for (int y = 0; y < height; y++) {
-      final rawSrcY = alignCorners ? y * scaleY : (y + 0.5) * scaleY - 0.5;
-      final srcY = rawSrcY.clamp(0.0, srcH - 1.0);
-      final y0 = srcY.floor().clamp(0, srcH - 1);
-      final y1 = (y0 + 1).clamp(0, srcH - 1);
-      final fy = srcY - y0;
+    // Dtype-specialized for hot path optimization
+    switch (input.dtype) {
+      case DType.float32:
+        final inList = input.storage.data as Float32List;
+        final outList = output.storage.data as Float32List;
+        for (int y = 0; y < height; y++) {
+          final rawSrcY = alignCorners ? y * scaleY : (y + 0.5) * scaleY - 0.5;
+          final srcY = rawSrcY.clamp(0.0, srcH - 1.0);
+          final y0 = srcY.floor().clamp(0, srcH - 1);
+          final y1 = (y0 + 1).clamp(0, srcH - 1);
+          final fy = srcY - y0;
+          final oneMinusFy = 1 - fy;
 
-      for (int x = 0; x < width; x++) {
-        final rawSrcX = alignCorners ? x * scaleX : (x + 0.5) * scaleX - 0.5;
-        final srcX = rawSrcX.clamp(0.0, srcW - 1.0);
-        final x0 = srcX.floor().clamp(0, srcW - 1);
-        final x1 = (x0 + 1).clamp(0, srcW - 1);
-        final fx = srcX - x0;
+          for (int x = 0; x < width; x++) {
+            final rawSrcX =
+                alignCorners ? x * scaleX : (x + 0.5) * scaleX - 0.5;
+            final srcX = rawSrcX.clamp(0.0, srcW - 1.0);
+            final x0 = srcX.floor().clamp(0, srcW - 1);
+            final x1 = (x0 + 1).clamp(0, srcW - 1);
+            final fx = srcX - x0;
+            final oneMinusFx = 1 - fx;
 
-        final v00 = input.storage.getAsDouble(srcOffset + y0 * srcW + x0);
-        final v01 = input.storage.getAsDouble(srcOffset + y0 * srcW + x1);
-        final v10 = input.storage.getAsDouble(srcOffset + y1 * srcW + x0);
-        final v11 = input.storage.getAsDouble(srcOffset + y1 * srcW + x1);
+            final v00 = inList[srcOffset + y0 * srcW + x0];
+            final v01 = inList[srcOffset + y0 * srcW + x1];
+            final v10 = inList[srcOffset + y1 * srcW + x0];
+            final v11 = inList[srcOffset + y1 * srcW + x1];
 
-        final value = v00 * (1 - fx) * (1 - fy) +
-            v01 * fx * (1 - fy) +
-            v10 * (1 - fx) * fy +
-            v11 * fx * fy;
+            final value = v00 * oneMinusFx * oneMinusFy +
+                v01 * fx * oneMinusFy +
+                v10 * oneMinusFx * fy +
+                v11 * fx * fy;
 
-        output.storage.setFromDouble(dstOffset + y * width + x, value);
-      }
+            outList[dstOffset + y * width + x] = value;
+          }
+        }
+      default:
+        // Generic fallback
+        for (int y = 0; y < height; y++) {
+          final rawSrcY = alignCorners ? y * scaleY : (y + 0.5) * scaleY - 0.5;
+          final srcY = rawSrcY.clamp(0.0, srcH - 1.0);
+          final y0 = srcY.floor().clamp(0, srcH - 1);
+          final y1 = (y0 + 1).clamp(0, srcH - 1);
+          final fy = srcY - y0;
+
+          for (int x = 0; x < width; x++) {
+            final rawSrcX =
+                alignCorners ? x * scaleX : (x + 0.5) * scaleX - 0.5;
+            final srcX = rawSrcX.clamp(0.0, srcW - 1.0);
+            final x0 = srcX.floor().clamp(0, srcW - 1);
+            final x1 = (x0 + 1).clamp(0, srcW - 1);
+            final fx = srcX - x0;
+
+            final v00 = input.storage.getAsDouble(srcOffset + y0 * srcW + x0);
+            final v01 = input.storage.getAsDouble(srcOffset + y0 * srcW + x1);
+            final v10 = input.storage.getAsDouble(srcOffset + y1 * srcW + x0);
+            final v11 = input.storage.getAsDouble(srcOffset + y1 * srcW + x1);
+
+            final value = v00 * (1 - fx) * (1 - fy) +
+                v01 * fx * (1 - fy) +
+                v10 * (1 - fx) * fy +
+                v11 * fx * fy;
+
+            output.storage.setFromDouble(dstOffset + y * width + x, value);
+          }
+        }
     }
   }
 
@@ -251,32 +310,104 @@ class ResizeOp extends TransformOp with RequiresContiguous {
     final scaleX =
         alignCorners && width > 1 ? (srcW - 1) / (width - 1) : srcW / width;
 
-    for (int y = 0; y < height; y++) {
-      final rawSrcY = alignCorners ? y * scaleY : (y + 0.5) * scaleY - 0.5;
-      final srcY = rawSrcY.clamp(0.0, srcH - 1.0);
-      final y0 = srcY.floor();
-      final fy = srcY - y0;
+    // Dtype-specialized for hot path optimization
+    switch (input.dtype) {
+      case DType.float32:
+        final inList = input.storage.data as Float32List;
+        final outList = output.storage.data as Float32List;
+        for (int y = 0; y < height; y++) {
+          final rawSrcY = alignCorners ? y * scaleY : (y + 0.5) * scaleY - 0.5;
+          final srcY = rawSrcY.clamp(0.0, srcH - 1.0);
+          final y0 = srcY.floor();
+          final fy = srcY - y0;
 
-      for (int x = 0; x < width; x++) {
-        final rawSrcX = alignCorners ? x * scaleX : (x + 0.5) * scaleX - 0.5;
-        final srcX = rawSrcX.clamp(0.0, srcW - 1.0);
-        final x0 = srcX.floor();
-        final fx = srcX - x0;
+          // Pre-compute y weights
+          final wy0 = _cubicWeight(-1 - fy);
+          final wy1 = _cubicWeight(-fy);
+          final wy2 = _cubicWeight(1 - fy);
+          final wy3 = _cubicWeight(2 - fy);
 
-        double value = 0.0;
-        for (int j = -1; j <= 2; j++) {
-          final yj = (y0 + j).clamp(0, srcH - 1);
-          final wy = _cubicWeight(j - fy);
-          for (int i = -1; i <= 2; i++) {
-            final xi = (x0 + i).clamp(0, srcW - 1);
-            final wx = _cubicWeight(i - fx);
-            final v = input.storage.getAsDouble(srcOffset + yj * srcW + xi);
-            value += v * wx * wy;
+          // Pre-compute y indices
+          final yj0 = (y0 - 1).clamp(0, srcH - 1);
+          final yj1 = y0.clamp(0, srcH - 1);
+          final yj2 = (y0 + 1).clamp(0, srcH - 1);
+          final yj3 = (y0 + 2).clamp(0, srcH - 1);
+
+          for (int x = 0; x < width; x++) {
+            final rawSrcX =
+                alignCorners ? x * scaleX : (x + 0.5) * scaleX - 0.5;
+            final srcX = rawSrcX.clamp(0.0, srcW - 1.0);
+            final x0 = srcX.floor();
+            final fx = srcX - x0;
+
+            // Pre-compute x weights
+            final wx0 = _cubicWeight(-1 - fx);
+            final wx1 = _cubicWeight(-fx);
+            final wx2 = _cubicWeight(1 - fx);
+            final wx3 = _cubicWeight(2 - fx);
+
+            // Pre-compute x indices
+            final xi0 = (x0 - 1).clamp(0, srcW - 1);
+            final xi1 = x0.clamp(0, srcW - 1);
+            final xi2 = (x0 + 1).clamp(0, srcW - 1);
+            final xi3 = (x0 + 2).clamp(0, srcW - 1);
+
+            // Unrolled 4x4 kernel for performance
+            final value = wy0 *
+                    (wx0 * inList[srcOffset + yj0 * srcW + xi0] +
+                        wx1 * inList[srcOffset + yj0 * srcW + xi1] +
+                        wx2 * inList[srcOffset + yj0 * srcW + xi2] +
+                        wx3 * inList[srcOffset + yj0 * srcW + xi3]) +
+                wy1 *
+                    (wx0 * inList[srcOffset + yj1 * srcW + xi0] +
+                        wx1 * inList[srcOffset + yj1 * srcW + xi1] +
+                        wx2 * inList[srcOffset + yj1 * srcW + xi2] +
+                        wx3 * inList[srcOffset + yj1 * srcW + xi3]) +
+                wy2 *
+                    (wx0 * inList[srcOffset + yj2 * srcW + xi0] +
+                        wx1 * inList[srcOffset + yj2 * srcW + xi1] +
+                        wx2 * inList[srcOffset + yj2 * srcW + xi2] +
+                        wx3 * inList[srcOffset + yj2 * srcW + xi3]) +
+                wy3 *
+                    (wx0 * inList[srcOffset + yj3 * srcW + xi0] +
+                        wx1 * inList[srcOffset + yj3 * srcW + xi1] +
+                        wx2 * inList[srcOffset + yj3 * srcW + xi2] +
+                        wx3 * inList[srcOffset + yj3 * srcW + xi3]);
+
+            outList[dstOffset + y * width + x] = value;
           }
         }
+      default:
+        // Generic fallback
+        for (int y = 0; y < height; y++) {
+          final rawSrcY = alignCorners ? y * scaleY : (y + 0.5) * scaleY - 0.5;
+          final srcY = rawSrcY.clamp(0.0, srcH - 1.0);
+          final y0 = srcY.floor();
+          final fy = srcY - y0;
 
-        output.storage.setFromDouble(dstOffset + y * width + x, value);
-      }
+          for (int x = 0; x < width; x++) {
+            final rawSrcX =
+                alignCorners ? x * scaleX : (x + 0.5) * scaleX - 0.5;
+            final srcX = rawSrcX.clamp(0.0, srcW - 1.0);
+            final x0 = srcX.floor();
+            final fx = srcX - x0;
+
+            double value = 0.0;
+            for (int j = -1; j <= 2; j++) {
+              final yj = (y0 + j).clamp(0, srcH - 1);
+              final wy = _cubicWeight(j - fy);
+              for (int i = -1; i <= 2; i++) {
+                final xi = (x0 + i).clamp(0, srcW - 1);
+                final wx = _cubicWeight(i - fx);
+                final v =
+                    input.storage.getAsDouble(srcOffset + yj * srcW + xi);
+                value += v * wx * wy;
+              }
+            }
+
+            output.storage.setFromDouble(dstOffset + y * width + x, value);
+          }
+        }
     }
   }
 
@@ -433,15 +564,38 @@ class CenterCropOp extends TransformOp with RequiresContiguous {
 
     final output = TensorBuffer.zeros([c, height, width], dtype: input.dtype);
 
-    for (int ch = 0; ch < c; ch++) {
-      for (int y = 0; y < height; y++) {
-        for (int x = 0; x < width; x++) {
-          final srcIdx = ch * srcH * srcW + (startY + y) * srcW + (startX + x);
-          final dstIdx = ch * height * width + y * width + x;
-          final value = input.storage.getAsDouble(srcIdx);
-          output.storage.setFromDouble(dstIdx, value);
+    // Dtype-specialized for hot path optimization
+    switch (input.dtype) {
+      case DType.float32:
+        final inList = input.storage.data as Float32List;
+        final outList = output.storage.data as Float32List;
+        final srcChannelStride = srcH * srcW;
+        final dstChannelStride = height * width;
+        for (int ch = 0; ch < c; ch++) {
+          final srcChOffset = ch * srcChannelStride;
+          final dstChOffset = ch * dstChannelStride;
+          for (int y = 0; y < height; y++) {
+            final srcRowOffset = srcChOffset + (startY + y) * srcW + startX;
+            final dstRowOffset = dstChOffset + y * width;
+            // Row-wise copy for better cache performance
+            for (int x = 0; x < width; x++) {
+              outList[dstRowOffset + x] = inList[srcRowOffset + x];
+            }
+          }
         }
-      }
+      default:
+        // Generic fallback
+        for (int ch = 0; ch < c; ch++) {
+          for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+              final srcIdx =
+                  ch * srcH * srcW + (startY + y) * srcW + (startX + x);
+              final dstIdx = ch * height * width + y * width + x;
+              final value = input.storage.getAsDouble(srcIdx);
+              output.storage.setFromDouble(dstIdx, value);
+            }
+          }
+        }
     }
 
     return output;
@@ -458,22 +612,48 @@ class CenterCropOp extends TransformOp with RequiresContiguous {
 
     final srcBatchStride = c * srcH * srcW;
     final dstBatchStride = c * height * width;
+    final srcChannelStride = srcH * srcW;
+    final dstChannelStride = height * width;
 
-    for (int batch = 0; batch < n; batch++) {
-      for (int ch = 0; ch < c; ch++) {
-        for (int y = 0; y < height; y++) {
-          for (int x = 0; x < width; x++) {
-            final srcIdx = batch * srcBatchStride +
-                ch * srcH * srcW +
-                (startY + y) * srcW +
-                (startX + x);
-            final dstIdx =
-                batch * dstBatchStride + ch * height * width + y * width + x;
-            final value = input.storage.getAsDouble(srcIdx);
-            output.storage.setFromDouble(dstIdx, value);
+    // Dtype-specialized for hot path optimization
+    switch (input.dtype) {
+      case DType.float32:
+        final inList = input.storage.data as Float32List;
+        final outList = output.storage.data as Float32List;
+        for (int batch = 0; batch < n; batch++) {
+          final srcBatchOffset = batch * srcBatchStride;
+          final dstBatchOffset = batch * dstBatchStride;
+          for (int ch = 0; ch < c; ch++) {
+            final srcChOffset = srcBatchOffset + ch * srcChannelStride;
+            final dstChOffset = dstBatchOffset + ch * dstChannelStride;
+            for (int y = 0; y < height; y++) {
+              final srcRowOffset = srcChOffset + (startY + y) * srcW + startX;
+              final dstRowOffset = dstChOffset + y * width;
+              // Row-wise copy for better cache performance
+              for (int x = 0; x < width; x++) {
+                outList[dstRowOffset + x] = inList[srcRowOffset + x];
+              }
+            }
           }
         }
-      }
+      default:
+        // Generic fallback
+        for (int batch = 0; batch < n; batch++) {
+          for (int ch = 0; ch < c; ch++) {
+            for (int y = 0; y < height; y++) {
+              for (int x = 0; x < width; x++) {
+                final srcIdx = batch * srcBatchStride +
+                    ch * srcChannelStride +
+                    (startY + y) * srcW +
+                    (startX + x);
+                final dstIdx =
+                    batch * dstBatchStride + ch * dstChannelStride + y * width + x;
+                final value = input.storage.getAsDouble(srcIdx);
+                output.storage.setFromDouble(dstIdx, value);
+              }
+            }
+          }
+        }
     }
 
     return output;

--- a/lib/src/pipeline/tensor_pipeline.dart
+++ b/lib/src/pipeline/tensor_pipeline.dart
@@ -56,10 +56,30 @@ class TensorPipeline {
     return result;
   }
 
+  /// Default threshold for using isolate execution.
+  ///
+  /// Tensors with fewer elements than this will run synchronously
+  /// to avoid isolate serialization overhead.
+  static const int defaultIsolateThreshold = 100000;
+
   /// Applies all operations to [input] asynchronously in a separate isolate.
   ///
   /// This is useful for non-blocking execution on large tensors.
-  Future<TensorBuffer> runAsync(TensorBuffer input) async {
+  ///
+  /// The [isolateThreshold] parameter controls the minimum number of elements
+  /// required to use isolate execution. For tensors smaller than this threshold,
+  /// the pipeline runs synchronously to avoid serialization overhead.
+  /// Set to 0 to always use isolate, or to a very large value to always run sync.
+  /// Default is [defaultIsolateThreshold] (100,000 elements).
+  Future<TensorBuffer> runAsync(
+    TensorBuffer input, {
+    int isolateThreshold = defaultIsolateThreshold,
+  }) async {
+    // For small tensors, skip isolate overhead and run synchronously
+    if (input.numel < isolateThreshold) {
+      return run(input);
+    }
+
     final inputData = _serializeTensor(input);
 
     final resultData = await Isolate.run(() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tensor_preprocessing
 description: >-
   High-performance tensor preprocessing library for Flutter/Dart.
   NumPy-like transforms pipeline for ONNX Runtime inference.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/brody-0125/dart_tensor_preprocessing
 homepage: https://github.com/brody-0125/dart_tensor_preprocessing
 


### PR DESCRIPTION
- **Dtype-specialized loops**: Hot paths in transform operations now use dtype-specific code paths with direct `Float32List`/`Float64List` access, avoiding per-element switch overhead:
  - `NormalizeOp._normalize3D()`, `NormalizeOp._normalize4D()`
  - `ScaleOp._scale()`
  - `ClipOp._clip()`
  - `GaussianBlurOp._applySeparableBlur()`
  - `ResizeOp._resizeNearest()`, `_resizeBilinear()`, `_resizeBicubic()`
  - `CenterCropOp._crop3D()`, `_crop4D()`
  - `concat()` with optimized axis=0 bulk copy
- **Clone-Before-Modify optimization**: `ClipOp.apply()` now avoids double copy by checking `isContiguous` before deciding whether to `clone()` or `contiguous()`
- **Isolate threshold**: `TensorPipeline.runAsync()` now accepts optional `isolateThreshold` parameter (default: 100,000 elements). Small tensors skip isolate overhead and run synchronously
- **Buffer reuse**: `GaussianBlurOp` now pre-allocates and reuses temp buffer across channels, reducing allocations
- **Concat linear copy**: `concat()` now uses pre-computed strides for linear index calculation instead of recursive index computation. Axis=0 concatenation of contiguous tensors uses bulk `setRange()` copy
- **Loop unrolling**: `ResizeOp._resizeBicubic()` unrolls 4x4 kernel with pre-computed weights and indices
