### PR TITLE
feat: support batch, layer normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-01-10
+
+### Added
+
+- **BatchNormOp** - Batch normalization for CNN inference (`batch_norm_op.dart`):
+  - Full PyTorch-compatible `torch.nn.BatchNorm2d` implementation
+  - Pre-computed scale/shift coefficients for efficient inference: `y = x * scale + shift`
+  - Supports 3D `[C,H,W]` and 4D `[N,C,H,W]` tensors
+  - `BatchNormOp.fromStateDict()` factory for loading PyTorch weights
+  - Dtype-specialized loops for Float32/Float64
+  - In-place support via `applyInPlace()`
+
+- **LayerNormOp** - Layer normalization for Transformer inference (`layer_norm_op.dart`):
+  - Full PyTorch-compatible `torch.nn.LayerNorm` implementation
+  - Normalizes over last N dimensions (e.g., `[768]` for BERT)
+  - **Welford's algorithm** for numerically stable mean/variance computation
+  - `LayerNormOp.bert()` and `LayerNormOp.bertLarge()` factory presets
+  - `LayerNormOp.fromStateDict()` factory for loading PyTorch weights
+  - Dtype-specialized loops for Float32/Float64
+  - In-place support via `applyInPlace()`
+
+### PyTorch Compatibility
+
+| Operation | PyTorch Equivalent |
+|-----------|-------------------|
+| `BatchNormOp` | `torch.nn.BatchNorm2d` (inference) |
+| `LayerNormOp` | `torch.nn.LayerNorm` |
+
 ## [0.4.1] - 2026-01-09
 
 ### Performance Optimizations

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tensor preprocessing library for Flutter/Dart. NumPy-like transforms pipeline fo
 
 ```yaml
 dependencies:
-  dart_tensor_preprocessing: ^0.4.1
+  dart_tensor_preprocessing: ^0.5.0
 ```
 
 ## Quick Start
@@ -81,6 +81,8 @@ final result = await pipeline.runAsync(input, isolateThreshold: 50000);
 ### Normalization
 - `NormalizeOp` - Channel-wise normalization (presets: ImageNet, CIFAR-10, symmetric)
 - `ScaleOp` - Scale values (e.g., [0-255] to [0-1])
+- `BatchNormOp` - Batch normalization for CNN inference (PyTorch compatible)
+- `LayerNormOp` - Layer normalization for Transformer inference (presets: BERT, BERT-Large)
 
 ### Layout
 - `PermuteOp` - Axis reordering (e.g., HWC to CHW)
@@ -176,6 +178,8 @@ This library is designed to produce identical results to PyTorch/torchvision ope
 | `ReLUOp` / `LeakyReLUOp` | `F.relu()` / `F.leaky_relu()` |
 | `SigmoidOp` / `TanhOp` | `torch.sigmoid()` / `torch.tanh()` |
 | `SoftmaxOp` | `F.softmax()` |
+| `BatchNormOp` | `torch.nn.BatchNorm2d` (inference) |
+| `LayerNormOp` | `torch.nn.LayerNorm` |
 | `TensorBuffer.full()` | `torch.full()` |
 | `TensorBuffer.random()` | `torch.rand()` |
 | `TensorBuffer.randn()` | `torch.randn()` |

--- a/benchmark/normalization_benchmark.dart
+++ b/benchmark/normalization_benchmark.dart
@@ -1,0 +1,289 @@
+/// Normalization operations performance benchmarks.
+///
+/// Benchmarks BatchNormOp and LayerNormOp for various tensor sizes
+/// to measure CNN and Transformer inference performance.
+// ignore_for_file: avoid_print
+library;
+
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+
+import 'utils/benchmark_utils.dart';
+
+// Shared tensors and operations for benchmarking
+late TensorBuffer _tensor;
+late BatchNormOp _batchNormOp;
+late LayerNormOp _layerNormOp;
+
+/// Runs all normalization benchmarks.
+Future<List<BenchmarkResult>> runNormalizationBenchmarks() async {
+  final results = <BenchmarkResult>[];
+
+  // ===== BatchNormOp Benchmarks =====
+  printHeader('BatchNormOp (CNN Inference)');
+
+  // Common CNN input sizes (NCHW format)
+  // Sources:
+  // - MobileNetV2: https://arxiv.org/abs/1801.04381 (Sandler et al., 2018)
+  // - ResNet-50: https://arxiv.org/abs/1512.03385 (He et al., 2015)
+  //   - Bottleneck structure: [1x1, c] -> [3x3, c] -> [1x1, 4c]
+  //   - Stage outputs: conv2_x=256, conv3_x=512, conv4_x=1024, conv5_x=2048
+  // - YOLOv5: https://github.com/ultralytics/yolov5 (detection head at 640x640 input)
+  final batchNormConfigs = [
+    // (name, shape, channels)
+    // MobileNetV2 first conv: 224->112, 32 channels (verified)
+    ('MobileNet [1,32,112,112]', [1, 32, 112, 112], 32),
+    // ResNet-50 bottleneck inner layer: 56x56, 64 channels (conv2_x 1x1 conv)
+    ('ResNet early [1,64,56,56]', [1, 64, 56, 56], 64),
+    // ResNet-50 bottleneck inner layer: 28x28, 256 channels (conv3_x 3x3 conv)
+    ('ResNet mid [1,256,28,28]', [1, 256, 28, 28], 256),
+    // ResNet-50 bottleneck inner layer: 14x14, 512 channels (conv4_x 3x3 conv)
+    ('ResNet late [1,512,14,14]', [1, 512, 14, 14], 512),
+    // ResNet-50 conv5_x output: 7x7, 2048 channels (stage output, verified)
+    ('ResNet final [1,2048,7,7]', [1, 2048, 7, 7], 2048),
+    // YOLOv5 P3 feature map: 80x80 at 640 input, 256 channels
+    ('YOLO [1,256,80,80]', [1, 256, 80, 80], 256),
+  ];
+
+  for (final (name, shape, channels) in batchNormConfigs) {
+    // Create BatchNormOp with realistic parameters
+    _batchNormOp = BatchNormOp(
+      runningMean: List.filled(channels, 0.0),
+      runningVar: List.filled(channels, 1.0),
+      weight: List.filled(channels, 1.0),
+      bias: List.filled(channels, 0.0),
+    );
+
+    // Create input tensor
+    final numel = shape.reduce((a, b) => a * b);
+    _tensor = TensorBuffer.fromFloat32List(
+      Float32List(numel),
+      shape,
+    );
+
+    final result = await benchmark(
+      'BatchNorm $name',
+      () => _batchNormOp.apply(_tensor),
+      iterations: numel > 500000 ? 20 : 50,
+    );
+    results.add(result);
+    print(result);
+  }
+
+  // BatchNorm in-place benchmark
+  print('');
+  print('--- In-place Operations ---');
+
+  for (final (name, shape, channels) in batchNormConfigs.take(3)) {
+    _batchNormOp = BatchNormOp(
+      runningMean: List.filled(channels, 0.0),
+      runningVar: List.filled(channels, 1.0),
+      weight: List.filled(channels, 1.0),
+      bias: List.filled(channels, 0.0),
+    );
+
+    final numel = shape.reduce((a, b) => a * b);
+
+    final result = await benchmark(
+      'BatchNorm.inPlace $name',
+      () {
+        // Create fresh tensor each iteration for in-place
+        _tensor = TensorBuffer.fromFloat32List(Float32List(numel), shape);
+        _batchNormOp.applyInPlace(_tensor);
+      },
+      iterations: numel > 500000 ? 20 : 50,
+    );
+    results.add(result);
+    print(result);
+  }
+
+  // ===== LayerNormOp Benchmarks =====
+  printHeader('LayerNormOp (Transformer Inference)');
+
+  // Common Transformer input sizes [batch, seq_len, hidden_dim]
+  // Sources:
+  // - BERT: https://arxiv.org/abs/1810.04805 (Devlin et al., 2018)
+  //   - base: hidden_size=768, max_position=512
+  //   - large: hidden_size=1024, max_position=512
+  // - GPT-2: https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf
+  //   - small: hidden_size=768, context=1024
+  //   - medium: hidden_size=1024, context=1024
+  //   - large: hidden_size=1280, context=1024
+  // - LLaMA: https://arxiv.org/abs/2302.13971 (Touvron et al., 2023)
+  //   - 7B: hidden_size=4096, context=2048
+  final layerNormConfigs = [
+    // (name, shape, normalizedShape)
+    // BERT-base: 768 hidden, 128 tokens (common inference length)
+    ('BERT-base [1,128,768]', [1, 128, 768], [768]),
+    // BERT-base: 768 hidden, 512 tokens (max length)
+    ('BERT-base [1,512,768]', [1, 512, 768], [768]),
+    // BERT-large: 1024 hidden, 128 tokens
+    ('BERT-large [1,128,1024]', [1, 128, 1024], [1024]),
+    // BERT-large: 1024 hidden, 512 tokens (max length)
+    ('BERT-large [1,512,1024]', [1, 512, 1024], [1024]),
+    // GPT-2 small: 768 hidden, 1024 context
+    ('GPT-2 [1,1024,768]', [1, 1024, 768], [768]),
+    // GPT-2 large: 1280 hidden, 1024 context
+    ('GPT-2 large [1,1024,1280]', [1, 1024, 1280], [1280]),
+    // LLaMA-7B: 4096 hidden, 2048 context
+    ('LLaMA-7B style [1,2048,4096]', [1, 2048, 4096], [4096]),
+  ];
+
+  for (final (name, shape, normalizedShape) in layerNormConfigs) {
+    final normalizedSize = normalizedShape.reduce((a, b) => a * b);
+
+    _layerNormOp = LayerNormOp(
+      normalizedShape: normalizedShape,
+      weight: List.filled(normalizedSize, 1.0),
+      bias: List.filled(normalizedSize, 0.0),
+    );
+
+    final numel = shape.reduce((a, b) => a * b);
+    _tensor = TensorBuffer.fromFloat32List(
+      Float32List(numel),
+      shape,
+    );
+
+    final result = await benchmark(
+      'LayerNorm $name',
+      () => _layerNormOp.apply(_tensor),
+      iterations: numel > 500000 ? 10 : 50,
+    );
+    results.add(result);
+    print(result);
+  }
+
+  // LayerNorm in-place benchmark
+  print('');
+  print('--- In-place Operations ---');
+
+  for (final (name, shape, normalizedShape) in layerNormConfigs.take(4)) {
+    final normalizedSize = normalizedShape.reduce((a, b) => a * b);
+
+    _layerNormOp = LayerNormOp(
+      normalizedShape: normalizedShape,
+      weight: List.filled(normalizedSize, 1.0),
+      bias: List.filled(normalizedSize, 0.0),
+    );
+
+    final numel = shape.reduce((a, b) => a * b);
+
+    final result = await benchmark(
+      'LayerNorm.inPlace $name',
+      () {
+        _tensor = TensorBuffer.fromFloat32List(Float32List(numel), shape);
+        _layerNormOp.applyInPlace(_tensor);
+      },
+      iterations: numel > 500000 ? 10 : 50,
+    );
+    results.add(result);
+    print(result);
+  }
+
+  // ===== Multi-dimensional LayerNorm =====
+  printHeader('LayerNormOp Multi-Dimensional');
+
+  // Vision Transformer style: normalize over trailing dimensions
+  // Sources:
+  // - ViT: https://arxiv.org/abs/2010.11929 (Dosovitskiy et al., 2020)
+  //   - ViT-B/16: 196 patches (224/16)^2, 768 hidden
+  final multiDimConfigs = [
+    // ViT-Base: 196 patches (14x14 grid from 224x224 image), 768 hidden
+    ('ViT patch [1,196,768]', [1, 196, 768], [768]),
+    // ViT spatial normalization: normalize over spatial dims
+    ('ViT [1,196,14,14] over [14,14]', [1, 196, 14, 14], [14, 14]),
+    // Conv2D instance norm style: normalize over spatial dims
+    ('Conv2D [1,64,28,28] over [28,28]', [1, 64, 28, 28], [28, 28]),
+  ];
+
+  for (final (name, shape, normalizedShape) in multiDimConfigs) {
+    final normalizedSize = normalizedShape.reduce((a, b) => a * b);
+
+    _layerNormOp = LayerNormOp(
+      normalizedShape: normalizedShape,
+      weight: List.filled(normalizedSize, 1.0),
+      bias: List.filled(normalizedSize, 0.0),
+    );
+
+    final numel = shape.reduce((a, b) => a * b);
+    _tensor = TensorBuffer.fromFloat32List(
+      Float32List(numel),
+      shape,
+    );
+
+    final result = await benchmark(
+      'LayerNorm $name',
+      () => _layerNormOp.apply(_tensor),
+      iterations: 50,
+    );
+    results.add(result);
+    print(result);
+  }
+
+  // ===== Comparison Summary =====
+  printHeader('Throughput Summary (elements/sec)');
+
+  // Calculate throughput for representative configs
+  final throughputTests = [
+    ('BatchNorm ResNet-mid', [1, 256, 28, 28], 'batch', 256),
+    ('LayerNorm BERT-base', [1, 512, 768], 'layer', 768),
+  ];
+
+  for (final (name, shape, type, param) in throughputTests) {
+    final numel = shape.reduce((a, b) => a * b);
+
+    if (type == 'batch') {
+      _batchNormOp = BatchNormOp(
+        runningMean: List.filled(param, 0.0),
+        runningVar: List.filled(param, 1.0),
+        weight: List.filled(param, 1.0),
+        bias: List.filled(param, 0.0),
+      );
+      _tensor = TensorBuffer.fromFloat32List(Float32List(numel), shape);
+
+      final result = await benchmark(
+        name,
+        () => _batchNormOp.apply(_tensor),
+        iterations: 100,
+      );
+
+      final elementsPerSec = numel * result.opsPerSecond;
+      print('$name: ${_formatElements(elementsPerSec)} elements/sec');
+    } else {
+      _layerNormOp = LayerNormOp(
+        normalizedShape: [param],
+        weight: List.filled(param, 1.0),
+        bias: List.filled(param, 0.0),
+      );
+      _tensor = TensorBuffer.fromFloat32List(Float32List(numel), shape);
+
+      final result = await benchmark(
+        name,
+        () => _layerNormOp.apply(_tensor),
+        iterations: 100,
+      );
+
+      final elementsPerSec = numel * result.opsPerSecond;
+      print('$name: ${_formatElements(elementsPerSec)} elements/sec');
+    }
+  }
+
+  return results;
+}
+
+String _formatElements(double elements) {
+  if (elements >= 1e9) {
+    return '${(elements / 1e9).toStringAsFixed(2)}B';
+  } else if (elements >= 1e6) {
+    return '${(elements / 1e6).toStringAsFixed(2)}M';
+  } else if (elements >= 1e3) {
+    return '${(elements / 1e3).toStringAsFixed(2)}K';
+  }
+  return elements.toStringAsFixed(0);
+}
+
+/// Runs benchmarks if executed directly.
+void main() async {
+  await runNormalizationBenchmarks();
+}

--- a/benchmark/run_all.dart
+++ b/benchmark/run_all.dart
@@ -8,6 +8,7 @@ import 'tensor_creation_benchmark.dart' as creation;
 import 'tensor_ops_benchmark.dart' as ops;
 import 'pipeline_benchmark.dart' as pipeline;
 import 'memory_benchmark.dart' as memory;
+import 'normalization_benchmark.dart' as normalization;
 import 'utils/benchmark_utils.dart';
 
 void main() async {
@@ -22,6 +23,7 @@ void main() async {
   await creation.runTensorCreationBenchmarks();
   await ops.runTensorOpsBenchmarks();
   await pipeline.runPipelineBenchmarks();
+  await normalization.runNormalizationBenchmarks();
   await memory.runMemoryBenchmarks();
 
   stopwatch.stop();

--- a/lib/dart_tensor_preprocessing.dart
+++ b/lib/dart_tensor_preprocessing.dart
@@ -49,5 +49,7 @@ export 'src/ops/concat_op.dart';
 export 'src/ops/arithmetic_op.dart';
 export 'src/ops/math_op.dart';
 export 'src/ops/activation_op.dart';
+export 'src/ops/batch_norm_op.dart';
+export 'src/ops/layer_norm_op.dart';
 export 'src/pipeline/tensor_pipeline.dart';
 export 'src/pipeline/presets.dart';

--- a/lib/src/ops/batch_norm_op.dart
+++ b/lib/src/ops/batch_norm_op.dart
@@ -1,0 +1,326 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import '../core/dtype.dart';
+import '../core/tensor_buffer.dart';
+import '../exceptions/tensor_exceptions.dart';
+import 'transform_op.dart';
+
+/// Batch Normalization for inference.
+///
+/// Applies the formula: `y = (x - running_mean) / sqrt(running_var + eps) * weight + bias`
+///
+/// This operation uses running statistics (computed during training) to normalize
+/// activations. It is essential for running pretrained CNN models like ResNet, VGG,
+/// and MobileNet.
+///
+/// Equivalent to `torch.nn.BatchNorm2d` in PyTorch (inference mode).
+///
+/// ## Example
+///
+/// ```dart
+/// final batchNorm = BatchNormOp(
+///   runningMean: [0.5, 0.5, 0.5],
+///   runningVar: [0.25, 0.25, 0.25],
+///   weight: [1.0, 1.0, 1.0],
+///   bias: [0.0, 0.0, 0.0],
+/// );
+/// final result = batchNorm(tensor);
+/// ```
+class BatchNormOp extends TransformOp with InPlaceTransform, RequiresContiguous {
+  /// Learned per-channel mean from training (running_mean).
+  final List<double> runningMean;
+
+  /// Learned per-channel variance from training (running_var).
+  final List<double> runningVar;
+
+  /// Optional learned scale parameter (gamma/weight).
+  /// If null, defaults to 1.0 for all channels.
+  final List<double>? weight;
+
+  /// Optional learned bias parameter (beta/bias).
+  /// If null, defaults to 0.0 for all channels.
+  final List<double>? bias;
+
+  /// Small constant for numerical stability.
+  final double eps;
+
+  /// Pre-computed scale: weight / sqrt(running_var + eps)
+  late final List<double> _scale;
+
+  /// Pre-computed shift: bias - running_mean * scale
+  late final List<double> _shift;
+
+  /// Creates a batch normalization operation.
+  ///
+  /// - [runningMean]: Per-channel mean values from training
+  /// - [runningVar]: Per-channel variance values from training
+  /// - [weight]: Optional per-channel scale (gamma), defaults to 1.0
+  /// - [bias]: Optional per-channel bias (beta), defaults to 0.0
+  /// - [eps]: Small constant to avoid division by zero (default: 1e-5)
+  BatchNormOp({
+    required this.runningMean,
+    required this.runningVar,
+    this.weight,
+    this.bias,
+    this.eps = 1e-5,
+  }) {
+    _validateParameters();
+    _precomputeCoefficients();
+  }
+
+  /// Creates a batch normalization from PyTorch state_dict Float32Lists.
+  factory BatchNormOp.fromStateDict({
+    required Float32List runningMean,
+    required Float32List runningVar,
+    Float32List? weight,
+    Float32List? bias,
+    double eps = 1e-5,
+  }) {
+    return BatchNormOp(
+      runningMean: runningMean.toList(),
+      runningVar: runningVar.toList(),
+      weight: weight?.toList(),
+      bias: bias?.toList(),
+      eps: eps,
+    );
+  }
+
+  void _validateParameters() {
+    final numChannels = runningMean.length;
+
+    if (numChannels == 0) {
+      throw InvalidParameterException(
+        'runningMean',
+        'empty',
+        'BatchNormOp requires at least one channel',
+      );
+    }
+
+    if (runningVar.length != numChannels) {
+      throw InvalidParameterException(
+        'runningVar',
+        'length ${runningVar.length}',
+        'Must match runningMean length ($numChannels)',
+      );
+    }
+
+    if (weight != null && weight!.length != numChannels) {
+      throw InvalidParameterException(
+        'weight',
+        'length ${weight!.length}',
+        'Must match runningMean length ($numChannels)',
+      );
+    }
+
+    if (bias != null && bias!.length != numChannels) {
+      throw InvalidParameterException(
+        'bias',
+        'length ${bias!.length}',
+        'Must match runningMean length ($numChannels)',
+      );
+    }
+
+    if (eps <= 0) {
+      throw InvalidParameterException(
+        'eps',
+        eps.toString(),
+        'Must be positive',
+      );
+    }
+
+    // Check for negative variance
+    for (int i = 0; i < numChannels; i++) {
+      if (runningVar[i] < 0) {
+        throw InvalidParameterException(
+          'runningVar[$i]',
+          runningVar[i].toString(),
+          'Variance cannot be negative',
+        );
+      }
+    }
+  }
+
+  /// Pre-computes scale and shift for efficient inference.
+  ///
+  /// y = (x - mean) / sqrt(var + eps) * w + b
+  ///   = x * (w / sqrt(var + eps)) + (b - mean * w / sqrt(var + eps))
+  ///   = x * scale + shift
+  void _precomputeCoefficients() {
+    final numChannels = runningMean.length;
+    _scale = List<double>.filled(numChannels, 0.0);
+    _shift = List<double>.filled(numChannels, 0.0);
+
+    for (int i = 0; i < numChannels; i++) {
+      final invStd = 1.0 / math.sqrt(runningVar[i] + eps);
+      final w = weight?[i] ?? 1.0;
+      final b = bias?[i] ?? 0.0;
+
+      _scale[i] = w * invStd;
+      _shift[i] = b - runningMean[i] * _scale[i];
+    }
+  }
+
+  /// Number of channels this batch norm expects.
+  int get numChannels => runningMean.length;
+
+  @override
+  String get name => 'BatchNorm(channels=$numChannels, eps=$eps)';
+
+  @override
+  TensorBuffer apply(TensorBuffer input) {
+    _validateShape(input.shape);
+
+    // Optimized: single copy regardless of contiguity
+    final TensorBuffer output;
+    if (input.isContiguous) {
+      output = input.clone();
+    } else {
+      output = input.contiguous();
+    }
+
+    _batchNorm(output);
+    return output;
+  }
+
+  @override
+  void applyInPlace(TensorBuffer input) {
+    if (!input.isContiguous) {
+      throw const NonContiguousException('BatchNormOp.applyInPlace');
+    }
+    _validateShape(input.shape);
+    _batchNorm(input);
+  }
+
+  void _validateShape(List<int> shape) {
+    final rank = shape.length;
+    if (rank != 3 && rank != 4) {
+      throw ShapeMismatchException(
+        actual: shape,
+        message: 'BatchNormOp requires 3D [C,H,W] or 4D [N,C,H,W] tensor',
+      );
+    }
+
+    final channels = rank == 3 ? shape[0] : shape[1];
+    if (channels != numChannels) {
+      throw ShapeMismatchException(
+        actual: shape,
+        message:
+            'Tensor has $channels channels, but BatchNormOp expects $numChannels',
+      );
+    }
+  }
+
+  void _batchNorm(TensorBuffer tensor) {
+    final shape = tensor.shape;
+    final rank = shape.length;
+
+    if (rank == 3) {
+      _batchNorm3D(tensor);
+    } else {
+      _batchNorm4D(tensor);
+    }
+  }
+
+  void _batchNorm3D(TensorBuffer tensor) {
+    final c = tensor.shape[0];
+    final h = tensor.shape[1];
+    final w = tensor.shape[2];
+    final channelSize = h * w;
+    final data = tensor.storage.data;
+
+    switch (tensor.dtype) {
+      case DType.float32:
+        final list = data as Float32List;
+        for (int ch = 0; ch < c; ch++) {
+          final offset = ch * channelSize;
+          final s = _scale[ch];
+          final sh = _shift[ch];
+          for (int i = 0; i < channelSize; i++) {
+            final idx = offset + i;
+            list[idx] = list[idx] * s + sh;
+          }
+        }
+      case DType.float64:
+        final list = data as Float64List;
+        for (int ch = 0; ch < c; ch++) {
+          final offset = ch * channelSize;
+          final s = _scale[ch];
+          final sh = _shift[ch];
+          for (int i = 0; i < channelSize; i++) {
+            final idx = offset + i;
+            list[idx] = list[idx] * s + sh;
+          }
+        }
+      default:
+        for (int ch = 0; ch < c; ch++) {
+          final offset = ch * channelSize;
+          final s = _scale[ch];
+          final sh = _shift[ch];
+          for (int i = 0; i < channelSize; i++) {
+            final idx = offset + i;
+            final value = tensor.storage.getAsDouble(idx);
+            tensor.storage.setFromDouble(idx, value * s + sh);
+          }
+        }
+    }
+  }
+
+  void _batchNorm4D(TensorBuffer tensor) {
+    final n = tensor.shape[0];
+    final c = tensor.shape[1];
+    final h = tensor.shape[2];
+    final w = tensor.shape[3];
+    final channelSize = h * w;
+    final batchSize = c * channelSize;
+    final data = tensor.storage.data;
+
+    switch (tensor.dtype) {
+      case DType.float32:
+        final list = data as Float32List;
+        for (int batch = 0; batch < n; batch++) {
+          final batchOffset = batch * batchSize;
+          for (int ch = 0; ch < c; ch++) {
+            final offset = batchOffset + ch * channelSize;
+            final s = _scale[ch];
+            final sh = _shift[ch];
+            for (int i = 0; i < channelSize; i++) {
+              final idx = offset + i;
+              list[idx] = list[idx] * s + sh;
+            }
+          }
+        }
+      case DType.float64:
+        final list = data as Float64List;
+        for (int batch = 0; batch < n; batch++) {
+          final batchOffset = batch * batchSize;
+          for (int ch = 0; ch < c; ch++) {
+            final offset = batchOffset + ch * channelSize;
+            final s = _scale[ch];
+            final sh = _shift[ch];
+            for (int i = 0; i < channelSize; i++) {
+              final idx = offset + i;
+              list[idx] = list[idx] * s + sh;
+            }
+          }
+        }
+      default:
+        for (int batch = 0; batch < n; batch++) {
+          final batchOffset = batch * batchSize;
+          for (int ch = 0; ch < c; ch++) {
+            final offset = batchOffset + ch * channelSize;
+            final s = _scale[ch];
+            final sh = _shift[ch];
+            for (int i = 0; i < channelSize; i++) {
+              final idx = offset + i;
+              final value = tensor.storage.getAsDouble(idx);
+              tensor.storage.setFromDouble(idx, value * s + sh);
+            }
+          }
+        }
+    }
+  }
+
+  @override
+  List<int> computeOutputShape(List<int> inputShape) => inputShape;
+}

--- a/lib/src/ops/layer_norm_op.dart
+++ b/lib/src/ops/layer_norm_op.dart
@@ -1,0 +1,323 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import '../core/dtype.dart';
+import '../core/tensor_buffer.dart';
+import '../exceptions/tensor_exceptions.dart';
+import 'transform_op.dart';
+
+/// Layer Normalization for inference.
+///
+/// Applies the formula: `y = (x - mean) / sqrt(var + eps) * weight + bias`
+/// where mean and variance are computed over the normalized dimensions.
+///
+/// This operation normalizes across feature dimensions (not batch), making it
+/// essential for Transformer models like BERT, ViT, and GPT.
+///
+/// Equivalent to `torch.nn.LayerNorm` in PyTorch.
+///
+/// ## Example
+///
+/// ```dart
+/// // For BERT-style transformer with hidden size 768
+/// final layerNorm = LayerNormOp(
+///   normalizedShape: [768],
+///   weight: gammaWeights,
+///   bias: betaWeights,
+/// );
+/// final result = layerNorm(tensor);
+/// ```
+class LayerNormOp extends TransformOp with InPlaceTransform, RequiresContiguous {
+  /// Shape of the normalized dimensions (e.g., [768] for BERT).
+  ///
+  /// Normalization is performed over the last N dimensions where
+  /// N = normalizedShape.length.
+  final List<int> normalizedShape;
+
+  /// Optional learned scale parameter (gamma/weight).
+  /// If null, defaults to 1.0 for all elements.
+  final List<double>? weight;
+
+  /// Optional learned bias parameter (beta/bias).
+  /// If null, defaults to 0.0 for all elements.
+  final List<double>? bias;
+
+  /// Small constant for numerical stability.
+  final double eps;
+
+  /// Number of elements in the normalized dimensions.
+  late final int _normalizedSize;
+
+  /// Creates a layer normalization operation.
+  ///
+  /// - [normalizedShape]: Shape of dimensions to normalize over (from right)
+  /// - [weight]: Optional per-element scale (gamma), defaults to 1.0
+  /// - [bias]: Optional per-element bias (beta), defaults to 0.0
+  /// - [eps]: Small constant to avoid division by zero (default: 1e-5)
+  LayerNormOp({
+    required this.normalizedShape,
+    this.weight,
+    this.bias,
+    this.eps = 1e-5,
+  }) {
+    _validateParameters();
+    _normalizedSize = normalizedShape.fold(1, (a, b) => a * b);
+  }
+
+  /// Creates a layer normalization for BERT-base (hidden size 768).
+  factory LayerNormOp.bert({
+    required List<double> weight,
+    required List<double> bias,
+    double eps = 1e-5,
+  }) {
+    return LayerNormOp(
+      normalizedShape: [768],
+      weight: weight,
+      bias: bias,
+      eps: eps,
+    );
+  }
+
+  /// Creates a layer normalization for BERT-large (hidden size 1024).
+  factory LayerNormOp.bertLarge({
+    required List<double> weight,
+    required List<double> bias,
+    double eps = 1e-5,
+  }) {
+    return LayerNormOp(
+      normalizedShape: [1024],
+      weight: weight,
+      bias: bias,
+      eps: eps,
+    );
+  }
+
+  /// Creates a layer normalization from PyTorch state_dict Float32Lists.
+  factory LayerNormOp.fromStateDict({
+    required List<int> normalizedShape,
+    Float32List? weight,
+    Float32List? bias,
+    double eps = 1e-5,
+  }) {
+    return LayerNormOp(
+      normalizedShape: normalizedShape,
+      weight: weight?.toList(),
+      bias: bias?.toList(),
+      eps: eps,
+    );
+  }
+
+  void _validateParameters() {
+    if (normalizedShape.isEmpty) {
+      throw InvalidParameterException(
+        'normalizedShape',
+        'empty',
+        'LayerNormOp requires at least one dimension',
+      );
+    }
+
+    for (int i = 0; i < normalizedShape.length; i++) {
+      if (normalizedShape[i] <= 0) {
+        throw InvalidParameterException(
+          'normalizedShape[$i]',
+          normalizedShape[i].toString(),
+          'Must be positive',
+        );
+      }
+    }
+
+    final expectedSize = normalizedShape.fold(1, (a, b) => a * b);
+
+    if (weight != null && weight!.length != expectedSize) {
+      throw InvalidParameterException(
+        'weight',
+        'length ${weight!.length}',
+        'Must match normalizedShape product ($expectedSize)',
+      );
+    }
+
+    if (bias != null && bias!.length != expectedSize) {
+      throw InvalidParameterException(
+        'bias',
+        'length ${bias!.length}',
+        'Must match normalizedShape product ($expectedSize)',
+      );
+    }
+
+    if (eps <= 0) {
+      throw InvalidParameterException(
+        'eps',
+        eps.toString(),
+        'Must be positive',
+      );
+    }
+  }
+
+  /// Number of elements in the normalized shape.
+  int get normalizedSize => _normalizedSize;
+
+  @override
+  String get name =>
+      'LayerNorm(shape=$normalizedShape, eps=$eps)';
+
+  @override
+  TensorBuffer apply(TensorBuffer input) {
+    _validateShape(input.shape);
+
+    // Single-copy pattern
+    final TensorBuffer output;
+    if (input.isContiguous) {
+      output = input.clone();
+    } else {
+      output = input.contiguous();
+    }
+
+    _layerNorm(output);
+    return output;
+  }
+
+  @override
+  void applyInPlace(TensorBuffer input) {
+    if (!input.isContiguous) {
+      throw const NonContiguousException('LayerNormOp.applyInPlace');
+    }
+    _validateShape(input.shape);
+    _layerNorm(input);
+  }
+
+  void _validateShape(List<int> shape) {
+    final rank = shape.length;
+    final normDims = normalizedShape.length;
+
+    if (rank < normDims) {
+      throw ShapeMismatchException(
+        actual: shape,
+        message:
+            'Input rank ($rank) must be >= normalizedShape length ($normDims)',
+      );
+    }
+
+    // Check that trailing dimensions match normalizedShape
+    for (int i = 0; i < normDims; i++) {
+      final inputDimIdx = rank - normDims + i;
+      if (shape[inputDimIdx] != normalizedShape[i]) {
+        throw ShapeMismatchException(
+          actual: shape,
+          message:
+              'Input shape trailing dimensions must match normalizedShape. '
+              'Expected [..., ${normalizedShape.join(', ')}], got [..., ${shape.sublist(rank - normDims).join(', ')}]',
+        );
+      }
+    }
+  }
+
+  void _layerNorm(TensorBuffer tensor) {
+    final shape = tensor.shape;
+    final rank = shape.length;
+    final normDims = normalizedShape.length;
+
+    // Number of instances to normalize (product of leading dimensions)
+    int numInstances = 1;
+    for (int i = 0; i < rank - normDims; i++) {
+      numInstances *= shape[i];
+    }
+
+    final data = tensor.storage.data;
+
+    switch (tensor.dtype) {
+      case DType.float32:
+        final list = data as Float32List;
+        _layerNormFloat32(list, numInstances);
+      case DType.float64:
+        final list = data as Float64List;
+        _layerNormFloat64(list, numInstances);
+      default:
+        _layerNormGeneric(tensor, numInstances);
+    }
+  }
+
+  void _layerNormFloat32(Float32List data, int numInstances) {
+    for (int instance = 0; instance < numInstances; instance++) {
+      final offset = instance * _normalizedSize;
+
+      // Welford's algorithm for numerically stable mean and variance
+      double mean = 0.0;
+      double m2 = 0.0;
+      for (int i = 0; i < _normalizedSize; i++) {
+        final x = data[offset + i];
+        final delta = x - mean;
+        mean += delta / (i + 1);
+        m2 += delta * (x - mean);
+      }
+      final variance = _normalizedSize > 1 ? m2 / _normalizedSize : 0.0;
+
+      // Normalize
+      final invStd = 1.0 / math.sqrt(variance + eps);
+      for (int i = 0; i < _normalizedSize; i++) {
+        final idx = offset + i;
+        final normalized = (data[idx] - mean) * invStd;
+        final w = weight?[i] ?? 1.0;
+        final b = bias?[i] ?? 0.0;
+        data[idx] = normalized * w + b;
+      }
+    }
+  }
+
+  void _layerNormFloat64(Float64List data, int numInstances) {
+    for (int instance = 0; instance < numInstances; instance++) {
+      final offset = instance * _normalizedSize;
+
+      // Welford's algorithm for numerically stable mean and variance
+      double mean = 0.0;
+      double m2 = 0.0;
+      for (int i = 0; i < _normalizedSize; i++) {
+        final x = data[offset + i];
+        final delta = x - mean;
+        mean += delta / (i + 1);
+        m2 += delta * (x - mean);
+      }
+      final variance = _normalizedSize > 1 ? m2 / _normalizedSize : 0.0;
+
+      // Normalize
+      final invStd = 1.0 / math.sqrt(variance + eps);
+      for (int i = 0; i < _normalizedSize; i++) {
+        final idx = offset + i;
+        final normalized = (data[idx] - mean) * invStd;
+        final w = weight?[i] ?? 1.0;
+        final b = bias?[i] ?? 0.0;
+        data[idx] = normalized * w + b;
+      }
+    }
+  }
+
+  void _layerNormGeneric(TensorBuffer tensor, int numInstances) {
+    for (int instance = 0; instance < numInstances; instance++) {
+      final offset = instance * _normalizedSize;
+
+      // Welford's algorithm for numerically stable mean and variance
+      double mean = 0.0;
+      double m2 = 0.0;
+      for (int i = 0; i < _normalizedSize; i++) {
+        final x = tensor.storage.getAsDouble(offset + i);
+        final delta = x - mean;
+        mean += delta / (i + 1);
+        m2 += delta * (x - mean);
+      }
+      final variance = _normalizedSize > 1 ? m2 / _normalizedSize : 0.0;
+
+      // Normalize
+      final invStd = 1.0 / math.sqrt(variance + eps);
+      for (int i = 0; i < _normalizedSize; i++) {
+        final idx = offset + i;
+        final value = tensor.storage.getAsDouble(idx);
+        final normalized = (value - mean) * invStd;
+        final w = weight?[i] ?? 1.0;
+        final b = bias?[i] ?? 0.0;
+        tensor.storage.setFromDouble(idx, normalized * w + b);
+      }
+    }
+  }
+
+  @override
+  List<int> computeOutputShape(List<int> inputShape) => inputShape;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tensor_preprocessing
 description: >-
   High-performance tensor preprocessing library for Flutter/Dart.
   NumPy-like transforms pipeline for ONNX Runtime inference.
-version: 0.4.1
+version: 0.5.0
 repository: https://github.com/brody-0125/dart_tensor_preprocessing
 homepage: https://github.com/brody-0125/dart_tensor_preprocessing
 

--- a/test/batch_norm_op_test.dart
+++ b/test/batch_norm_op_test.dart
@@ -1,0 +1,359 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BatchNormOp', () {
+    group('constructor validation', () {
+      test('throws on empty runningMean', () {
+        expect(
+          () => BatchNormOp(runningMean: [], runningVar: []),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on mismatched runningVar length', () {
+        expect(
+          () => BatchNormOp(
+            runningMean: [0.5, 0.5, 0.5],
+            runningVar: [0.25, 0.25],
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on mismatched weight length', () {
+        expect(
+          () => BatchNormOp(
+            runningMean: [0.5, 0.5, 0.5],
+            runningVar: [0.25, 0.25, 0.25],
+            weight: [1.0, 1.0],
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on mismatched bias length', () {
+        expect(
+          () => BatchNormOp(
+            runningMean: [0.5, 0.5, 0.5],
+            runningVar: [0.25, 0.25, 0.25],
+            bias: [0.0, 0.0],
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on eps <= 0', () {
+        expect(
+          () => BatchNormOp(
+            runningMean: [0.5],
+            runningVar: [0.25],
+            eps: 0,
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+
+        expect(
+          () => BatchNormOp(
+            runningMean: [0.5],
+            runningVar: [0.25],
+            eps: -1e-5,
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on negative variance', () {
+        expect(
+          () => BatchNormOp(
+            runningMean: [0.5, 0.5],
+            runningVar: [0.25, -0.1],
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+    });
+
+    group('shape validation', () {
+      test('throws on 2D tensor', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5, 0.5],
+          runningVar: [0.25, 0.25, 0.25],
+        );
+        final tensor = TensorBuffer.zeros([3, 4]);
+
+        expect(
+          () => op.apply(tensor),
+          throwsA(isA<ShapeMismatchException>()),
+        );
+      });
+
+      test('throws on 5D tensor', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5, 0.5],
+          runningVar: [0.25, 0.25, 0.25],
+        );
+        final tensor = TensorBuffer.zeros([1, 3, 4, 4, 4]);
+
+        expect(
+          () => op.apply(tensor),
+          throwsA(isA<ShapeMismatchException>()),
+        );
+      });
+
+      test('throws on channel mismatch for 3D tensor', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5, 0.5],
+          runningVar: [0.25, 0.25, 0.25],
+        );
+        final tensor = TensorBuffer.zeros([2, 4, 4]); // 2 channels
+
+        expect(
+          () => op.apply(tensor),
+          throwsA(isA<ShapeMismatchException>()),
+        );
+      });
+
+      test('throws on channel mismatch for 4D tensor', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5, 0.5],
+          runningVar: [0.25, 0.25, 0.25],
+        );
+        final tensor = TensorBuffer.zeros([1, 2, 4, 4]); // 2 channels
+
+        expect(
+          () => op.apply(tensor),
+          throwsA(isA<ShapeMismatchException>()),
+        );
+      });
+    });
+
+    group('3D tensor normalization', () {
+      test('normalizes with identity parameters', () {
+        // Identity: mean=0, var=1, weight=1, bias=0 => y = x
+        final op = BatchNormOp(
+          runningMean: [0.0, 0.0, 0.0],
+          runningVar: [1.0, 1.0, 1.0],
+          weight: [1.0, 1.0, 1.0],
+          bias: [0.0, 0.0, 0.0],
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            // Channel 0
+            1.0, 2.0, 3.0, 4.0,
+            // Channel 1
+            5.0, 6.0, 7.0, 8.0,
+            // Channel 2
+            9.0, 10.0, 11.0, 12.0,
+          ]),
+          [3, 2, 2],
+        );
+
+        final output = op.apply(input);
+
+        expect(output.shape, [3, 2, 2]);
+        // With identity params, output should equal input
+        for (int i = 0; i < input.numel; i++) {
+          expect(
+            output.storage.getAsDouble(i),
+            closeTo(input.storage.getAsDouble(i), 1e-4),
+          );
+        }
+      });
+
+      test('normalizes with default weight/bias', () {
+        // No weight/bias provided => defaults to weight=1, bias=0
+        final op = BatchNormOp(
+          runningMean: [1.0, 2.0],
+          runningVar: [0.25, 0.25], // std = 0.5
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            // Channel 0: values around mean=1
+            0.5, 1.0, 1.5, 2.0,
+            // Channel 1: values around mean=2
+            1.5, 2.0, 2.5, 3.0,
+          ]),
+          [2, 2, 2],
+        );
+
+        final output = op.apply(input);
+
+        // For channel 0: (x - 1) / sqrt(0.25 + 1e-5) ≈ (x - 1) / 0.5
+        // For channel 1: (x - 2) / sqrt(0.25 + 1e-5) ≈ (x - 2) / 0.5
+        final expected = [
+          // Channel 0
+          (0.5 - 1) / math.sqrt(0.25 + 1e-5),
+          (1.0 - 1) / math.sqrt(0.25 + 1e-5),
+          (1.5 - 1) / math.sqrt(0.25 + 1e-5),
+          (2.0 - 1) / math.sqrt(0.25 + 1e-5),
+          // Channel 1
+          (1.5 - 2) / math.sqrt(0.25 + 1e-5),
+          (2.0 - 2) / math.sqrt(0.25 + 1e-5),
+          (2.5 - 2) / math.sqrt(0.25 + 1e-5),
+          (3.0 - 2) / math.sqrt(0.25 + 1e-5),
+        ];
+
+        for (int i = 0; i < expected.length; i++) {
+          expect(output.storage.getAsDouble(i), closeTo(expected[i], 1e-5));
+        }
+      });
+
+      test('normalizes with custom weight and bias', () {
+        final op = BatchNormOp(
+          runningMean: [0.0],
+          runningVar: [1.0],
+          weight: [2.0],
+          bias: [1.0],
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, 2.0, 3.0, 4.0]),
+          [1, 2, 2],
+        );
+
+        final output = op.apply(input);
+
+        // y = x * 2 + 1
+        expect(output.storage.getAsDouble(0), closeTo(3.0, 1e-4));
+        expect(output.storage.getAsDouble(1), closeTo(5.0, 1e-4));
+        expect(output.storage.getAsDouble(2), closeTo(7.0, 1e-4));
+        expect(output.storage.getAsDouble(3), closeTo(9.0, 1e-4));
+      });
+    });
+
+    group('4D tensor normalization', () {
+      test('normalizes batch of images', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5],
+          runningVar: [0.25, 0.25],
+        );
+
+        // 2 batches, 2 channels, 2x2 spatial
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            // Batch 0
+            // Channel 0
+            0.0, 0.5, 1.0, 1.5,
+            // Channel 1
+            0.0, 0.5, 1.0, 1.5,
+            // Batch 1
+            // Channel 0
+            0.25, 0.75, 1.25, 1.75,
+            // Channel 1
+            0.25, 0.75, 1.25, 1.75,
+          ]),
+          [2, 2, 2, 2],
+        );
+
+        final output = op.apply(input);
+
+        expect(output.shape, [2, 2, 2, 2]);
+
+        // Verify batch 0, channel 0, first element
+        final invStd = 1.0 / math.sqrt(0.25 + 1e-5);
+        expect(
+          output.storage.getAsDouble(0),
+          closeTo((0.0 - 0.5) * invStd, 1e-5),
+        );
+      });
+    });
+
+    group('fromStateDict factory', () {
+      test('creates BatchNormOp from Float32Lists', () {
+        final op = BatchNormOp.fromStateDict(
+          runningMean: Float32List.fromList([0.5, 0.5, 0.5]),
+          runningVar: Float32List.fromList([0.25, 0.25, 0.25]),
+          weight: Float32List.fromList([1.0, 1.0, 1.0]),
+          bias: Float32List.fromList([0.0, 0.0, 0.0]),
+        );
+
+        expect(op.numChannels, 3);
+      });
+    });
+
+    group('in-place operation', () {
+      test('applyInPlace modifies tensor directly', () {
+        final op = BatchNormOp(
+          runningMean: [0.5],
+          runningVar: [0.25],
+        );
+
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([0.0, 0.5, 1.0, 1.5]),
+          [1, 2, 2],
+        );
+
+        op.applyInPlace(tensor);
+
+        final invStd = 1.0 / math.sqrt(0.25 + 1e-5);
+        expect(tensor.storage.getAsDouble(0), closeTo(-0.5 * invStd, 1e-5));
+        expect(tensor.storage.getAsDouble(1), closeTo(0.0, 1e-5));
+      });
+
+      test('applyInPlace throws on non-contiguous tensor', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5, 0.5],
+          runningVar: [0.25, 0.25, 0.25],
+        );
+
+        final tensor = TensorBuffer.zeros([3, 4, 4]).transpose([1, 0, 2]);
+
+        expect(
+          () => op.applyInPlace(tensor),
+          throwsA(isA<NonContiguousException>()),
+        );
+      });
+    });
+
+    group('properties', () {
+      test('name includes channel count and eps', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5, 0.5],
+          runningVar: [0.25, 0.25, 0.25],
+          eps: 1e-6,
+        );
+
+        expect(op.name, contains('3'));
+        expect(op.name, contains('0.000001'));
+      });
+
+      test('computeOutputShape returns input shape', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5, 0.5],
+          runningVar: [0.25, 0.25, 0.25],
+        );
+
+        expect(op.computeOutputShape([3, 224, 224]), [3, 224, 224]);
+        expect(op.computeOutputShape([1, 3, 224, 224]), [1, 3, 224, 224]);
+      });
+    });
+
+    group('non-contiguous input', () {
+      test('handles transposed tensor', () {
+        final op = BatchNormOp(
+          runningMean: [0.0, 0.0],
+          runningVar: [1.0, 1.0],
+        );
+
+        // Create transposed (non-contiguous) tensor
+        final original = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8]),
+          [2, 2, 2],
+        );
+        final transposed = original.transpose([1, 0, 2]);
+
+        // Should still work (will make contiguous internally)
+        final output = op.apply(transposed);
+
+        expect(output.shape, [2, 2, 2]);
+        expect(output.isContiguous, true);
+      });
+    });
+  });
+}

--- a/test/layer_norm_op_test.dart
+++ b/test/layer_norm_op_test.dart
@@ -1,0 +1,393 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LayerNormOp', () {
+    group('constructor validation', () {
+      test('throws on empty normalizedShape', () {
+        expect(
+          () => LayerNormOp(normalizedShape: []),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on zero in normalizedShape', () {
+        expect(
+          () => LayerNormOp(normalizedShape: [768, 0]),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on negative in normalizedShape', () {
+        expect(
+          () => LayerNormOp(normalizedShape: [-1]),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on mismatched weight length', () {
+        expect(
+          () => LayerNormOp(
+            normalizedShape: [4],
+            weight: [1.0, 1.0, 1.0], // 3 != 4
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on mismatched bias length', () {
+        expect(
+          () => LayerNormOp(
+            normalizedShape: [4],
+            bias: [0.0, 0.0], // 2 != 4
+          ),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('throws on eps <= 0', () {
+        expect(
+          () => LayerNormOp(normalizedShape: [4], eps: 0),
+          throwsA(isA<InvalidParameterException>()),
+        );
+
+        expect(
+          () => LayerNormOp(normalizedShape: [4], eps: -1e-5),
+          throwsA(isA<InvalidParameterException>()),
+        );
+      });
+
+      test('accepts multi-dimensional normalizedShape', () {
+        final op = LayerNormOp(
+          normalizedShape: [2, 3],
+          weight: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+          bias: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        expect(op.normalizedSize, 6);
+      });
+    });
+
+    group('shape validation', () {
+      test('throws on insufficient rank', () {
+        final op = LayerNormOp(normalizedShape: [4, 4]);
+        final tensor = TensorBuffer.zeros([4]); // rank 1 < 2
+
+        expect(
+          () => op.apply(tensor),
+          throwsA(isA<ShapeMismatchException>()),
+        );
+      });
+
+      test('throws on trailing dimension mismatch', () {
+        final op = LayerNormOp(normalizedShape: [768]);
+        final tensor = TensorBuffer.zeros([2, 512]); // 512 != 768
+
+        expect(
+          () => op.apply(tensor),
+          throwsA(isA<ShapeMismatchException>()),
+        );
+      });
+
+      test('throws on multi-dim shape mismatch', () {
+        final op = LayerNormOp(normalizedShape: [4, 4]);
+        final tensor = TensorBuffer.zeros([2, 4, 3]); // [4, 3] != [4, 4]
+
+        expect(
+          () => op.apply(tensor),
+          throwsA(isA<ShapeMismatchException>()),
+        );
+      });
+    });
+
+    group('2D tensor normalization', () {
+      test('normalizes with identity parameters', () {
+        // Identity: weight=1, bias=0
+        final op = LayerNormOp(
+          normalizedShape: [4],
+          weight: [1.0, 1.0, 1.0, 1.0],
+          bias: [0.0, 0.0, 0.0, 0.0],
+        );
+
+        // Values with known mean=2.5, var=1.25
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, 2.0, 3.0, 4.0]),
+          [1, 4],
+        );
+
+        final output = op.apply(input);
+
+        expect(output.shape, [1, 4]);
+
+        // Expected: (x - 2.5) / sqrt(1.25 + 1e-5)
+        const mean = 2.5;
+        const variance = 1.25;
+        final invStd = 1.0 / math.sqrt(variance + 1e-5);
+
+        for (int i = 0; i < 4; i++) {
+          final expected = (input.storage.getAsDouble(i) - mean) * invStd;
+          expect(output.storage.getAsDouble(i), closeTo(expected, 1e-4));
+        }
+      });
+
+      test('normalizes batch of vectors', () {
+        final op = LayerNormOp(normalizedShape: [3]);
+
+        // 2 samples, 3 features each
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            1.0, 2.0, 3.0, // Sample 0: mean=2, var=2/3
+            4.0, 5.0, 6.0, // Sample 1: mean=5, var=2/3
+          ]),
+          [2, 3],
+        );
+
+        final output = op.apply(input);
+
+        expect(output.shape, [2, 3]);
+
+        // Sample 0
+        const mean0 = 2.0;
+        const var0 = 2.0 / 3.0;
+        final invStd0 = 1.0 / math.sqrt(var0 + 1e-5);
+        expect(output.storage.getAsDouble(0), closeTo((1.0 - mean0) * invStd0, 1e-4));
+        expect(output.storage.getAsDouble(1), closeTo((2.0 - mean0) * invStd0, 1e-4));
+        expect(output.storage.getAsDouble(2), closeTo((3.0 - mean0) * invStd0, 1e-4));
+
+        // Sample 1
+        const mean1 = 5.0;
+        const var1 = 2.0 / 3.0;
+        final invStd1 = 1.0 / math.sqrt(var1 + 1e-5);
+        expect(output.storage.getAsDouble(3), closeTo((4.0 - mean1) * invStd1, 1e-4));
+        expect(output.storage.getAsDouble(4), closeTo((5.0 - mean1) * invStd1, 1e-4));
+        expect(output.storage.getAsDouble(5), closeTo((6.0 - mean1) * invStd1, 1e-4));
+      });
+
+      test('normalizes with custom weight and bias', () {
+        final op = LayerNormOp(
+          normalizedShape: [2],
+          weight: [2.0, 0.5],
+          bias: [1.0, -1.0],
+        );
+
+        // Values: [0.0, 2.0] -> mean=1, var=1
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([0.0, 2.0]),
+          [1, 2],
+        );
+
+        final output = op.apply(input);
+
+        const mean = 1.0;
+        const variance = 1.0;
+        final invStd = 1.0 / math.sqrt(variance + 1e-5);
+
+        // First element: (0 - 1) / sqrt(1.00001) * 2 + 1
+        final norm0 = (0.0 - mean) * invStd;
+        expect(output.storage.getAsDouble(0), closeTo(norm0 * 2.0 + 1.0, 1e-4));
+
+        // Second element: (2 - 1) / sqrt(1.00001) * 0.5 - 1
+        final norm1 = (2.0 - mean) * invStd;
+        expect(output.storage.getAsDouble(1), closeTo(norm1 * 0.5 - 1.0, 1e-4));
+      });
+    });
+
+    group('3D tensor normalization', () {
+      test('normalizes [batch, seq, features] tensor', () {
+        final op = LayerNormOp(normalizedShape: [4]);
+
+        // [batch=2, seq=2, features=4]
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            // Batch 0
+            1.0, 2.0, 3.0, 4.0, // seq 0
+            5.0, 6.0, 7.0, 8.0, // seq 1
+            // Batch 1
+            0.0, 1.0, 2.0, 3.0, // seq 0
+            4.0, 5.0, 6.0, 7.0, // seq 1
+          ]),
+          [2, 2, 4],
+        );
+
+        final output = op.apply(input);
+
+        expect(output.shape, [2, 2, 4]);
+
+        // Each sequence position is normalized independently
+        // Batch 0, seq 0: [1,2,3,4] -> mean=2.5, var=1.25
+        const mean = 2.5;
+        const variance = 1.25;
+        final invStd = 1.0 / math.sqrt(variance + 1e-5);
+        expect(output.storage.getAsDouble(0), closeTo((1.0 - mean) * invStd, 1e-4));
+      });
+
+      test('normalizes over last 2 dimensions', () {
+        // Normalize over [2, 3] = 6 elements
+        final op = LayerNormOp(normalizedShape: [2, 3]);
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            // Instance 0 (6 elements)
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+            // Instance 1 (6 elements)
+            7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+          ]),
+          [2, 2, 3],
+        );
+
+        final output = op.apply(input);
+
+        expect(output.shape, [2, 2, 3]);
+
+        // Instance 0: mean=3.5
+        const mean0 = 3.5;
+        var var0 = 0.0;
+        for (int i = 0; i < 6; i++) {
+          final diff = (i + 1).toDouble() - mean0;
+          var0 += diff * diff;
+        }
+        var0 /= 6;
+        final invStd0 = 1.0 / math.sqrt(var0 + 1e-5);
+        expect(output.storage.getAsDouble(0), closeTo((1.0 - mean0) * invStd0, 1e-4));
+      });
+    });
+
+    group('factory constructors', () {
+      test('bert() creates 768-dim normalization', () {
+        final weight = List.filled(768, 1.0);
+        final bias = List.filled(768, 0.0);
+        final op = LayerNormOp.bert(weight: weight, bias: bias);
+
+        expect(op.normalizedSize, 768);
+        expect(op.normalizedShape, [768]);
+      });
+
+      test('bertLarge() creates 1024-dim normalization', () {
+        final weight = List.filled(1024, 1.0);
+        final bias = List.filled(1024, 0.0);
+        final op = LayerNormOp.bertLarge(weight: weight, bias: bias);
+
+        expect(op.normalizedSize, 1024);
+        expect(op.normalizedShape, [1024]);
+      });
+
+      test('fromStateDict() creates from Float32Lists', () {
+        final op = LayerNormOp.fromStateDict(
+          normalizedShape: [4],
+          weight: Float32List.fromList([1.0, 1.0, 1.0, 1.0]),
+          bias: Float32List.fromList([0.0, 0.0, 0.0, 0.0]),
+        );
+
+        expect(op.normalizedSize, 4);
+      });
+    });
+
+    group('in-place operation', () {
+      test('applyInPlace modifies tensor directly', () {
+        final op = LayerNormOp(normalizedShape: [4]);
+
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, 2.0, 3.0, 4.0]),
+          [1, 4],
+        );
+
+        op.applyInPlace(tensor);
+
+        // Should be normalized now
+        const mean = 2.5;
+        const variance = 1.25;
+        final invStd = 1.0 / math.sqrt(variance + 1e-5);
+        expect(tensor.storage.getAsDouble(0), closeTo((1.0 - mean) * invStd, 1e-4));
+      });
+
+      test('applyInPlace throws on non-contiguous tensor', () {
+        final op = LayerNormOp(normalizedShape: [4]);
+
+        final tensor = TensorBuffer.zeros([4, 4]).transpose([1, 0]);
+
+        expect(
+          () => op.applyInPlace(tensor),
+          throwsA(isA<NonContiguousException>()),
+        );
+      });
+    });
+
+    group('properties', () {
+      test('name includes shape and eps', () {
+        final op = LayerNormOp(
+          normalizedShape: [768],
+          eps: 1e-6,
+        );
+
+        expect(op.name, contains('[768]'));
+        expect(op.name, contains('0.000001'));
+      });
+
+      test('computeOutputShape returns input shape', () {
+        final op = LayerNormOp(normalizedShape: [768]);
+
+        expect(op.computeOutputShape([2, 10, 768]), [2, 10, 768]);
+        expect(op.computeOutputShape([768]), [768]);
+      });
+    });
+
+    group('non-contiguous input', () {
+      test('handles transposed tensor', () {
+        final op = LayerNormOp(normalizedShape: [2]);
+
+        // Create transposed (non-contiguous) tensor
+        final original = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1, 2, 3, 4]),
+          [2, 2],
+        );
+        final transposed = original.transpose([1, 0]);
+
+        // Should still work (will make contiguous internally)
+        final output = op.apply(transposed);
+
+        expect(output.shape, [2, 2]);
+        expect(output.isContiguous, true);
+      });
+    });
+
+    group('edge cases', () {
+      test('handles single element normalization', () {
+        final op = LayerNormOp(
+          normalizedShape: [1],
+          weight: [2.0],
+          bias: [1.0],
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([5.0]),
+          [1, 1],
+        );
+
+        final output = op.apply(input);
+
+        // Single element: mean=5, var=0, (x-mean)/sqrt(0+eps) * 2 + 1
+        // With var=0, the normalized value approaches 0
+        expect(output.storage.getAsDouble(0), closeTo(1.0, 1e-4)); // 0 * 2 + 1 = 1
+      });
+
+      test('handles constant input (zero variance)', () {
+        final op = LayerNormOp(normalizedShape: [4]);
+
+        // All same values -> mean=5, var=0
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([5.0, 5.0, 5.0, 5.0]),
+          [1, 4],
+        );
+
+        final output = op.apply(input);
+
+        // With zero variance, normalized values are all 0 (before affine)
+        for (int i = 0; i < 4; i++) {
+          expect(output.storage.getAsDouble(i), closeTo(0.0, 1e-4));
+        }
+      });
+    });
+  });
+}

--- a/test/pytorch_compatibility_test.dart
+++ b/test/pytorch_compatibility_test.dart
@@ -740,6 +740,255 @@ void main() {
       });
     });
 
+    group('BatchNormOp', () {
+      /// ```python
+      /// import torch
+      /// import torch.nn as nn
+      ///
+      /// # Create BatchNorm2d with specific running stats
+      /// bn = nn.BatchNorm2d(3, eps=1e-5, affine=True)
+      /// bn.running_mean = torch.tensor([0.5, 0.3, 0.7])
+      /// bn.running_var = torch.tensor([0.25, 0.16, 0.09])
+      /// bn.weight.data = torch.tensor([1.0, 2.0, 0.5])
+      /// bn.bias.data = torch.tensor([0.0, 1.0, -0.5])
+      /// bn.eval()  # inference mode
+      ///
+      /// x = torch.tensor([[[[1.0, 0.5], [0.0, 0.25]],
+      ///                    [[0.5, 0.3], [0.1, 0.2]],
+      ///                    [[0.8, 0.6], [0.7, 0.9]]]])
+      /// y = bn(x)
+      /// print(y[0, 0, 0, 0].item())  # 0.9999...
+      /// print(y[0, 1, 0, 0].item())  # 2.0
+      /// print(y[0, 2, 0, 0].item())  # -0.3333...
+      /// ```
+      test('BatchNormOp matches PyTorch nn.BatchNorm2d', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.3, 0.7],
+          runningVar: [0.25, 0.16, 0.09],
+          weight: [1.0, 2.0, 0.5],
+          bias: [0.0, 1.0, -0.5],
+          eps: 1e-5,
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            // Channel 0
+            1.0, 0.5, 0.0, 0.25,
+            // Channel 1
+            0.5, 0.3, 0.1, 0.2,
+            // Channel 2
+            0.8, 0.6, 0.7, 0.9,
+          ]),
+          [1, 3, 2, 2],
+        );
+
+        final output = op.apply(input);
+
+        // Channel 0: (1.0 - 0.5) / sqrt(0.25 + 1e-5) * 1.0 + 0.0
+        //          = 0.5 / 0.5 * 1.0 = ~1.0
+        expect(output[[0, 0, 0, 0]], closeTo(1.0, 1e-4));
+
+        // Channel 1: (0.5 - 0.3) / sqrt(0.16 + 1e-5) * 2.0 + 1.0
+        //          = 0.2 / 0.4 * 2.0 + 1.0 = 1.0 + 1.0 = ~2.0
+        expect(output[[0, 1, 0, 0]], closeTo(2.0, 1e-4));
+
+        // Channel 2: (0.8 - 0.7) / sqrt(0.09 + 1e-5) * 0.5 + (-0.5)
+        //          = 0.1 / 0.3 * 0.5 - 0.5 = ~-0.333
+        expect(output[[0, 2, 0, 0]], closeTo(-0.3333, 1e-3));
+      });
+
+      /// ```python
+      /// # 3D input [C, H, W]
+      /// x = torch.tensor([[[0.0, 1.0], [0.5, 0.5]],
+      ///                   [[0.2, 0.8], [0.4, 0.6]]])
+      /// bn = nn.BatchNorm2d(2, eps=1e-5)
+      /// bn.running_mean = torch.tensor([0.5, 0.5])
+      /// bn.running_var = torch.tensor([0.25, 0.25])
+      /// bn.eval()
+      /// y = bn(x.unsqueeze(0)).squeeze(0)
+      /// # (0.0 - 0.5) / sqrt(0.25 + 1e-5) = -1.0
+      /// print(y[0, 0, 0].item())  # -0.9999...
+      /// ```
+      test('BatchNormOp with 3D tensor matches PyTorch', () {
+        final op = BatchNormOp(
+          runningMean: [0.5, 0.5],
+          runningVar: [0.25, 0.25],
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            // Channel 0
+            0.0, 1.0, 0.5, 0.5,
+            // Channel 1
+            0.2, 0.8, 0.4, 0.6,
+          ]),
+          [2, 2, 2],
+        );
+
+        final output = op.apply(input);
+
+        // (0.0 - 0.5) / sqrt(0.25 + 1e-5) = -1.0
+        expect(output[[0, 0, 0]], closeTo(-1.0, 1e-4));
+        // (1.0 - 0.5) / sqrt(0.25 + 1e-5) = 1.0
+        expect(output[[0, 0, 1]], closeTo(1.0, 1e-4));
+        // (0.5 - 0.5) / sqrt(0.25 + 1e-5) = 0.0
+        expect(output[[0, 1, 0]], closeTo(0.0, 1e-4));
+      });
+
+      /// ```python
+      /// # Batch processing
+      /// x = torch.randn(4, 3, 8, 8)  # 4 batches
+      /// bn = nn.BatchNorm2d(3)
+      /// bn.running_mean = torch.tensor([0.0, 0.0, 0.0])
+      /// bn.running_var = torch.tensor([1.0, 1.0, 1.0])
+      /// bn.eval()
+      /// y = bn(x)
+      /// # Output should have same shape
+      /// assert y.shape == x.shape
+      /// ```
+      test('BatchNormOp preserves batch dimension', () {
+        final op = BatchNormOp(
+          runningMean: [0.0, 0.0, 0.0],
+          runningVar: [1.0, 1.0, 1.0],
+        );
+
+        final input = TensorBuffer.zeros([4, 3, 8, 8]);
+        final output = op.apply(input);
+
+        expect(output.shape, equals([4, 3, 8, 8]));
+      });
+    });
+
+    group('LayerNormOp', () {
+      /// ```python
+      /// import torch
+      /// import torch.nn as nn
+      ///
+      /// ln = nn.LayerNorm([4], eps=1e-5)
+      /// ln.weight.data = torch.tensor([1.0, 1.0, 1.0, 1.0])
+      /// ln.bias.data = torch.tensor([0.0, 0.0, 0.0, 0.0])
+      ///
+      /// x = torch.tensor([[1.0, 2.0, 3.0, 4.0]])  # mean=2.5, var=1.25
+      /// y = ln(x)
+      /// # (1.0 - 2.5) / sqrt(1.25 + 1e-5) = -1.3416...
+      /// print(y[0, 0].item())
+      /// ```
+      test('LayerNormOp matches PyTorch nn.LayerNorm', () {
+        final op = LayerNormOp(
+          normalizedShape: [4],
+          weight: [1.0, 1.0, 1.0, 1.0],
+          bias: [0.0, 0.0, 0.0, 0.0],
+          eps: 1e-5,
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, 2.0, 3.0, 4.0]),
+          [1, 4],
+        );
+
+        final output = op.apply(input);
+
+        // mean = 2.5, var = 1.25
+        // (1.0 - 2.5) / sqrt(1.25 + 1e-5) = -1.3416...
+        expect(output[[0, 0]], closeTo(-1.3416, 1e-3));
+        // (2.0 - 2.5) / sqrt(1.25 + 1e-5) = -0.4472...
+        expect(output[[0, 1]], closeTo(-0.4472, 1e-3));
+        // (3.0 - 2.5) / sqrt(1.25 + 1e-5) = 0.4472...
+        expect(output[[0, 2]], closeTo(0.4472, 1e-3));
+        // (4.0 - 2.5) / sqrt(1.25 + 1e-5) = 1.3416...
+        expect(output[[0, 3]], closeTo(1.3416, 1e-3));
+      });
+
+      /// ```python
+      /// # With weight and bias
+      /// ln = nn.LayerNorm([3], eps=1e-5)
+      /// ln.weight.data = torch.tensor([2.0, 1.0, 0.5])
+      /// ln.bias.data = torch.tensor([1.0, 0.0, -1.0])
+      ///
+      /// x = torch.tensor([[1.0, 2.0, 3.0],
+      ///                   [4.0, 5.0, 6.0]])  # 2 samples
+      /// y = ln(x)
+      /// # Sample 0: mean=2, var=2/3
+      /// # Sample 1: mean=5, var=2/3
+      /// ```
+      test('LayerNormOp with weight/bias matches PyTorch', () {
+        final op = LayerNormOp(
+          normalizedShape: [3],
+          weight: [2.0, 1.0, 0.5],
+          bias: [1.0, 0.0, -1.0],
+          eps: 1e-5,
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            1.0, 2.0, 3.0, // Sample 0
+            4.0, 5.0, 6.0, // Sample 1
+          ]),
+          [2, 3],
+        );
+
+        final output = op.apply(input);
+
+        // Sample 0: mean=2, var=2/3
+        // (1.0 - 2) / sqrt(2/3 + 1e-5) * 2.0 + 1.0 = -1.2247 * 2 + 1 = -1.4494
+        expect(output[[0, 0]], closeTo(-1.4494, 1e-3));
+        // (2.0 - 2) / sqrt(2/3 + 1e-5) * 1.0 + 0.0 = 0
+        expect(output[[0, 1]], closeTo(0.0, 1e-3));
+        // (3.0 - 2) / sqrt(2/3 + 1e-5) * 0.5 + (-1.0) = 0.6124 - 1 = -0.3876
+        expect(output[[0, 2]], closeTo(-0.3876, 1e-3));
+      });
+
+      /// ```python
+      /// # 3D input [batch, seq, features] - common for transformers
+      /// ln = nn.LayerNorm([768], eps=1e-5)
+      /// x = torch.randn(2, 10, 768)  # batch=2, seq=10, hidden=768
+      /// y = ln(x)
+      /// assert y.shape == x.shape
+      /// ```
+      test('LayerNormOp handles transformer-style input', () {
+        // Simplified test with smaller dimensions
+        final op = LayerNormOp(
+          normalizedShape: [8],
+          eps: 1e-5,
+        );
+
+        final input = TensorBuffer.zeros([2, 4, 8]); // [batch, seq, features]
+        final output = op.apply(input);
+
+        expect(output.shape, equals([2, 4, 8]));
+        // All zeros -> all outputs should be 0 (or NaN-safe value)
+        // With Welford algorithm and eps, should be 0
+      });
+
+      /// ```python
+      /// # Multi-dimensional normalized shape
+      /// ln = nn.LayerNorm([4, 4], eps=1e-5)
+      /// x = torch.randn(2, 4, 4)
+      /// y = ln(x)
+      /// assert y.shape == x.shape
+      /// ```
+      test('LayerNormOp with multi-dim normalized shape', () {
+        final op = LayerNormOp(
+          normalizedShape: [2, 3],
+          eps: 1e-5,
+        );
+
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, // Instance 0
+            7.0, 8.0, 9.0, 10.0, 11.0, 12.0, // Instance 1
+          ]),
+          [2, 2, 3],
+        );
+
+        final output = op.apply(input);
+
+        expect(output.shape, equals([2, 2, 3]));
+        // Instance 0: mean=3.5, values normalized
+        // Instance 1: mean=9.5, values normalized
+      });
+    });
+
     group('DType Compatibility', () {
       /// ```python
       /// t_f32 = torch.zeros(2, 3, dtype=torch.float32)


### PR DESCRIPTION
- **BatchNormOp** - Batch normalization for CNN inference (`batch_norm_op.dart`):
  - Full PyTorch-compatible `torch.nn.BatchNorm2d` implementation
  - Pre-computed scale/shift coefficients for efficient inference: `y = x * scale + shift`
  - Supports 3D `[C,H,W]` and 4D `[N,C,H,W]` tensors
  - `BatchNormOp.fromStateDict()` factory for loading PyTorch weights
  - Dtype-specialized loops for Float32/Float64
  - In-place support via `applyInPlace()`
- **LayerNormOp** - Layer normalization for Transformer inference (`layer_norm_op.dart`):
  - Full PyTorch-compatible `torch.nn.LayerNorm` implementation
  - Normalizes over last N dimensions (e.g., `[768]` for BERT)
  - **Welford's algorithm** for numerically stable mean/variance computation
  - `LayerNormOp.bert()` and `LayerNormOp.bertLarge()` factory presets
  - `LayerNormOp.fromStateDict()` factory for loading PyTorch weights
  - Dtype-specialized loops for Float32/Float64
  - In-place support via `applyInPlace()`