### PR TITLE
refactor: add memory optimization utilities and zero-copy views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-01-13
+
+### Added
+
+- **BufferPool** - Memory pooling API for buffer reuse (`buffer_pool.dart`):
+  - Singleton `BufferPool.instance` for global buffer reuse
+  - Power-of-2 size bucketing for efficient allocation
+  - Per-dtype buffer pools (Float32, Float64, Int32, Uint8, etc.)
+  - `acquire(minSize, dtype)` and `release(buffer)` methods
+  - `acquireFloat32()`, `acquireFloat64()`, etc. convenience extensions
+  - Max buffers per bucket limit (8) to prevent unbounded memory growth
+  - `pooledCount` and `pooledBytes` for monitoring
+
+- **TypedData Views** - Zero-copy tensor view utilities (`typed_data_views.dart`):
+  - `TypedDataViews.float32SublistView()` - Zero-copy Float32List slicing
+  - `TypedDataViews.float64SublistView()` - Zero-copy Float64List slicing
+  - `TypedDataViews.viewAs()` - Create typed view from ByteBuffer at offset
+  - `TensorViewExtension` on TensorBuffer:
+    - `sliceFirst(start, end)` - Zero-copy slice along first dimension
+    - `isViewable` - Check if tensor can be used as a view
+    - `toChannelsLast()` - NCHW to NHWC without copying
+    - `toChannelsFirst()` - NHWC to NCHW without copying
+    - `flatten()` - 1D view of contiguous tensor
+    - `unbind(dim)` - Split tensor into views along dimension
+    - `select(dim, index)` - Select single index with reduced rank
+    - `narrow(dim, start, length)` - Narrow dimension without copying
+
+- **Utility Libraries** (`lib/src/utils/`):
+  - `dtype_dispatcher.dart` - DTypeDispatcher for dtype-specialized dispatch
+  - `tensor_indexing.dart` - TensorIndexer for index calculations (index2D, index3D, index4D, linearToCoords, coordsToLinear, computeStrides)
+
+- **TensorBuffer/TensorStorage Factory Methods**:
+  - `TensorBuffer.fromFloat64List()` - Create tensor from Float64List
+  - `TensorStorage.fromFloat64List()` - Create storage from Float64List
+
+### Changed
+
+- **SoftmaxOp Optimization**: Now preserves input dtype (Float32/Float64) instead of always using Float64. Added dtype-specialized implementations for better performance.
+
+- **Double-copy elimination**: Operations now use `cloneForModification()` pattern (`input.isContiguous ? input.clone() : input.contiguous()`) to avoid unnecessary copies:
+  - `ReLUOp`, `LeakyReLUOp`, `SigmoidOp`, `TanhOp`, `SoftmaxOp`
+  - `AbsOp`, `NegOp`, `SqrtOp`, `ExpOp`, `LogOp` (UnaryMathOp)
+  - `NormalizeOp`, `ScaleOp`
+
+### Internal
+
+- Added `cloneForModification()` helper to `RequiresContiguous` mixin in `transform_op.dart`
+- Integrated `DTypeDispatcher` into activation ops (`ReLUOp`, `LeakyReLUOp`, `SigmoidOp`, `TanhOp`) for dtype-specialized loops
+- Integrated `DTypeDispatcher` into `ScaleOp` for consistent dtype handling
+- Replaced stride computation with `TensorIndexer.computeStrides()` in `SoftmaxOp` (removed 3x code duplication)
+
 ## [0.5.0] - 2026-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tensor preprocessing library for Flutter/Dart. NumPy-like transforms pipeline fo
 
 ```yaml
 dependencies:
-  dart_tensor_preprocessing: ^0.5.0
+  dart_tensor_preprocessing: ^0.5.1
 ```
 
 ## Quick Start
@@ -139,6 +139,50 @@ DType.int64    // ONNX ID: 7
 DType.uint8    // ONNX ID: 2
 ```
 
+### BufferPool
+
+Memory pooling for buffer reuse, reducing GC pressure in hot paths.
+
+```dart
+final pool = BufferPool.instance;
+
+// Acquire buffer (reuses from pool if available)
+final buffer = pool.acquireFloat32(1000);
+
+// ... use buffer ...
+
+// Release back to pool for reuse
+pool.release(buffer);
+
+// Monitor pool usage
+print('Pooled: ${pool.pooledCount} buffers, ${pool.pooledBytes} bytes');
+```
+
+### Zero-Copy View Operations
+
+TensorBuffer extension methods for zero-copy tensor manipulation:
+
+```dart
+// Slice along first dimension (batch slicing)
+final batch = tensor.sliceFirst(2, 5);  // Views elements 2..4
+
+// Split tensor into views
+final items = tensor.unbind(0);  // List of views along dim 0
+
+// Select single index (reduces rank)
+final first = tensor.select(0, 0);  // First item, shape reduced
+
+// Narrow dimension
+final narrowed = tensor.narrow(0, 1, 3);  // 3 elements starting at 1
+
+// Format conversion without copying
+final nhwc = nchwTensor.toChannelsLast();   // NCHW -> NHWC view
+final nchw = nhwcTensor.toChannelsFirst();  // NHWC -> NCHW view
+
+// Flatten to 1D view
+final flat = tensor.flatten();
+```
+
 ## Memory Formats
 
 | Format | Layout | Strides (for [1,3,224,224]) |
@@ -186,6 +230,10 @@ This library is designed to produce identical results to PyTorch/torchvision ope
 | `TensorBuffer.eye()` | `torch.eye()` |
 | `TensorBuffer.linspace()` | `torch.linspace()` |
 | `TensorBuffer.arange()` | `torch.arange()` |
+| `tensor.select(dim, index)` | `tensor.select(dim, index)` |
+| `tensor.narrow(dim, start, len)` | `tensor.narrow(dim, start, len)` |
+| `tensor.unbind(dim)` | `tensor.unbind(dim)` |
+| `tensor.flatten()` | `tensor.flatten()` |
 
 ## Performance Benchmarks
 

--- a/lib/dart_tensor_preprocessing.dart
+++ b/lib/dart_tensor_preprocessing.dart
@@ -31,6 +31,7 @@
 /// See [PipelinePresets] for pre-configured pipelines for common models.
 library;
 
+export 'src/core/buffer_pool.dart';
 export 'src/core/dtype.dart';
 export 'src/core/memory_format.dart';
 export 'src/core/tensor_buffer.dart';
@@ -53,3 +54,6 @@ export 'src/ops/batch_norm_op.dart';
 export 'src/ops/layer_norm_op.dart';
 export 'src/pipeline/tensor_pipeline.dart';
 export 'src/pipeline/presets.dart';
+export 'src/utils/dtype_dispatcher.dart';
+export 'src/utils/tensor_indexing.dart';
+export 'src/utils/typed_data_views.dart';

--- a/lib/src/core/buffer_pool.dart
+++ b/lib/src/core/buffer_pool.dart
@@ -1,0 +1,131 @@
+import 'dart:typed_data';
+
+import 'dtype.dart';
+
+/// A pool of reusable TypedData buffers for memory optimization.
+///
+/// Reduces GC pressure by reusing buffers instead of allocating new ones.
+/// Buffers are organized by dtype and size buckets for efficient reuse.
+///
+/// ```dart
+/// final pool = BufferPool.instance;
+///
+/// // Acquire a buffer
+/// final buffer = pool.acquire(1000, DType.float32);
+///
+/// // ... use buffer ...
+///
+/// // Release back to pool
+/// pool.release(buffer);
+/// ```
+class BufferPool {
+  /// The singleton pool instance.
+  static final BufferPool instance = BufferPool._();
+
+  BufferPool._();
+
+  /// Creates a new buffer pool instance (for testing or isolated use).
+  factory BufferPool.create() => BufferPool._();
+
+  // Pools organized by dtype name -> size bucket -> list of buffers
+  final Map<String, Map<int, List<TypedData>>> _pools = {};
+
+  /// Maximum number of buffers to keep per bucket.
+  static const int maxBuffersPerBucket = 8;
+
+  /// Acquires a buffer of at least [minSize] elements with dtype [dtype].
+  ///
+  /// Returns a buffer from the pool if available, otherwise allocates new.
+  /// The returned buffer may be larger than requested (rounded up to bucket size).
+  TypedData acquire(int minSize, DType dtype) {
+    final bucketSize = _computeBucketSize(minSize);
+    final dtypePools = _pools[dtype.typeName] ??= {};
+    final bucket = dtypePools[bucketSize] ??= [];
+
+    if (bucket.isNotEmpty) {
+      return bucket.removeLast();
+    }
+
+    return dtype.createBuffer(bucketSize);
+  }
+
+  /// Releases a buffer back to the pool for reuse.
+  ///
+  /// The buffer will only be pooled if:
+  /// - The bucket hasn't reached [maxBuffersPerBucket]
+  /// - The buffer dtype can be determined
+  void release(TypedData buffer) {
+    final dtype = DType.fromTypedData(buffer);
+    final bucketSize = buffer.lengthInBytes ~/ dtype.byteSize;
+    final dtypePools = _pools[dtype.typeName] ??= {};
+    final bucket = dtypePools[bucketSize] ??= [];
+
+    // Limit pool size to prevent unbounded memory growth
+    if (bucket.length < maxBuffersPerBucket) {
+      bucket.add(buffer);
+    }
+  }
+
+  /// Clears all pooled buffers, releasing memory.
+  void clear() => _pools.clear();
+
+  /// The total number of buffers currently in the pool.
+  int get pooledCount {
+    int count = 0;
+    for (final dtypePools in _pools.values) {
+      for (final bucket in dtypePools.values) {
+        count += bucket.length;
+      }
+    }
+    return count;
+  }
+
+  /// The total memory held by pooled buffers in bytes.
+  int get pooledBytes {
+    int bytes = 0;
+    for (final dtypePools in _pools.values) {
+      for (final bucket in dtypePools.values) {
+        for (final buffer in bucket) {
+          bytes += buffer.lengthInBytes;
+        }
+      }
+    }
+    return bytes;
+  }
+
+  /// Compute size bucket (round up to power of 2 for efficient reuse).
+  int _computeBucketSize(int size) {
+    if (size <= 0) return 1;
+    int bucket = 1;
+    while (bucket < size) {
+      bucket *= 2;
+    }
+    return bucket;
+  }
+}
+
+/// Extension to add pool-aware operations to TensorBuffer.
+///
+/// This extension provides methods to work with [BufferPool] for
+/// memory-efficient tensor operations.
+extension BufferPoolExtension on BufferPool {
+  /// Acquires a Float32List of at least [minSize] elements.
+  Float32List acquireFloat32(int minSize) {
+    return acquire(minSize, DType.float32) as Float32List;
+  }
+
+  /// Acquires a Float64List of at least [minSize] elements.
+  Float64List acquireFloat64(int minSize) {
+    return acquire(minSize, DType.float64) as Float64List;
+  }
+
+  /// Acquires a Uint8List of at least [minSize] elements.
+  Uint8List acquireUint8(int minSize) {
+    return acquire(minSize, DType.uint8) as Uint8List;
+  }
+
+  /// Acquires an Int32List of at least [minSize] elements.
+  Int32List acquireInt32(int minSize) {
+    return acquire(minSize, DType.int32) as Int32List;
+  }
+}

--- a/lib/src/core/tensor_buffer.dart
+++ b/lib/src/core/tensor_buffer.dart
@@ -643,6 +643,23 @@ class TensorBuffer {
     );
   }
 
+  /// Creates a tensor from an existing [Float64List] with the given [shape].
+  ///
+  /// Throws [ShapeMismatchException] if data length doesn't match shape.
+  static TensorBuffer fromFloat64List(Float64List data, List<int> shape) {
+    final expectedNumel = shape.fold(1, (a, b) => a * b);
+    if (data.length != expectedNumel) {
+      throw ShapeMismatchException(
+        actual: shape,
+        message: 'Data length (${data.length}) does not match shape $shape (numel: $expectedNumel)',
+      );
+    }
+    return TensorBuffer(
+      storage: TensorStorage.fromFloat64List(data),
+      shape: List.unmodifiable(shape),
+    );
+  }
+
   /// Creates a tensor from an existing [Uint8List] with the given [shape].
   ///
   /// Throws [ShapeMismatchException] if data length doesn't match shape.

--- a/lib/src/core/tensor_storage.dart
+++ b/lib/src/core/tensor_storage.dart
@@ -30,6 +30,11 @@ class TensorStorage {
     return TensorStorage(data, DType.float32);
   }
 
+  /// Creates storage from a [Float64List].
+  factory TensorStorage.fromFloat64List(Float64List data) {
+    return TensorStorage(data, DType.float64);
+  }
+
   /// Creates storage from a [Uint8List].
   factory TensorStorage.fromUint8List(Uint8List data) {
     return TensorStorage(data, DType.uint8);

--- a/lib/src/ops/activation_op.dart
+++ b/lib/src/ops/activation_op.dart
@@ -1,9 +1,11 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
-import '../core/tensor_storage.dart';
 import '../exceptions/tensor_exceptions.dart';
+import '../utils/dtype_dispatcher.dart';
+import '../utils/tensor_indexing.dart';
 import 'transform_op.dart';
 
 /// Rectified Linear Unit (ReLU) activation function.
@@ -23,8 +25,7 @@ class ReLUOp extends TransformOp with InPlaceTransform, RequiresContiguous {
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-    final output = contiguous.clone();
+    final output = cloneForModification(input);
     _relu(output);
     return output;
   }
@@ -38,13 +39,26 @@ class ReLUOp extends TransformOp with InPlaceTransform, RequiresContiguous {
   }
 
   void _relu(TensorBuffer tensor) {
-    final numel = tensor.numel;
-    for (int i = 0; i < numel; i++) {
-      final value = tensor.storage.getAsDouble(i);
-      if (value < 0) {
-        tensor.storage.setFromDouble(i, 0.0);
-      }
-    }
+    DTypeDispatcher.dispatchVoid(
+      tensor,
+      onFloat32: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          if (list[i] < 0) list[i] = 0;
+        }
+      },
+      onFloat64: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          if (list[i] < 0) list[i] = 0;
+        }
+      },
+      fallback: (t) {
+        final n = t.numel;
+        for (int i = 0; i < n; i++) {
+          final value = t.storage.getAsDouble(i);
+          if (value < 0) t.storage.setFromDouble(i, 0.0);
+        }
+      },
+    );
   }
 
   @override
@@ -71,8 +85,7 @@ class LeakyReLUOp extends TransformOp with InPlaceTransform, RequiresContiguous 
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-    final output = contiguous.clone();
+    final output = cloneForModification(input);
     _leakyRelu(output);
     return output;
   }
@@ -86,13 +99,27 @@ class LeakyReLUOp extends TransformOp with InPlaceTransform, RequiresContiguous 
   }
 
   void _leakyRelu(TensorBuffer tensor) {
-    final numel = tensor.numel;
-    for (int i = 0; i < numel; i++) {
-      final value = tensor.storage.getAsDouble(i);
-      if (value < 0) {
-        tensor.storage.setFromDouble(i, value * negativeSlope);
-      }
-    }
+    final slope = negativeSlope;
+    DTypeDispatcher.dispatchVoid(
+      tensor,
+      onFloat32: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          if (list[i] < 0) list[i] *= slope;
+        }
+      },
+      onFloat64: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          if (list[i] < 0) list[i] *= slope;
+        }
+      },
+      fallback: (t) {
+        final n = t.numel;
+        for (int i = 0; i < n; i++) {
+          final value = t.storage.getAsDouble(i);
+          if (value < 0) t.storage.setFromDouble(i, value * slope);
+        }
+      },
+    );
   }
 
   @override
@@ -116,8 +143,7 @@ class SigmoidOp extends TransformOp with InPlaceTransform, RequiresContiguous {
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-    final output = contiguous.clone();
+    final output = cloneForModification(input);
     _sigmoid(output);
     return output;
   }
@@ -131,12 +157,26 @@ class SigmoidOp extends TransformOp with InPlaceTransform, RequiresContiguous {
   }
 
   void _sigmoid(TensorBuffer tensor) {
-    final numel = tensor.numel;
-    for (int i = 0; i < numel; i++) {
-      final value = tensor.storage.getAsDouble(i);
-      final result = 1.0 / (1.0 + math.exp(-value));
-      tensor.storage.setFromDouble(i, result);
-    }
+    DTypeDispatcher.dispatchVoid(
+      tensor,
+      onFloat32: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          list[i] = 1.0 / (1.0 + math.exp(-list[i]));
+        }
+      },
+      onFloat64: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          list[i] = 1.0 / (1.0 + math.exp(-list[i]));
+        }
+      },
+      fallback: (t) {
+        final n = t.numel;
+        for (int i = 0; i < n; i++) {
+          final value = t.storage.getAsDouble(i);
+          t.storage.setFromDouble(i, 1.0 / (1.0 + math.exp(-value)));
+        }
+      },
+    );
   }
 
   @override
@@ -160,8 +200,7 @@ class TanhOp extends TransformOp with InPlaceTransform, RequiresContiguous {
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-    final output = contiguous.clone();
+    final output = cloneForModification(input);
     _tanh(output);
     return output;
   }
@@ -175,15 +214,30 @@ class TanhOp extends TransformOp with InPlaceTransform, RequiresContiguous {
   }
 
   void _tanh(TensorBuffer tensor) {
-    final numel = tensor.numel;
-    for (int i = 0; i < numel; i++) {
-      final value = tensor.storage.getAsDouble(i);
-      // tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
-      // Using the formula that avoids overflow for large x
-      final exp2x = math.exp(2 * value);
-      final result = (exp2x - 1) / (exp2x + 1);
-      tensor.storage.setFromDouble(i, result);
-    }
+    // tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
+    DTypeDispatcher.dispatchVoid(
+      tensor,
+      onFloat32: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          final exp2x = math.exp(2 * list[i]);
+          list[i] = (exp2x - 1) / (exp2x + 1);
+        }
+      },
+      onFloat64: (list, numel) {
+        for (int i = 0; i < numel; i++) {
+          final exp2x = math.exp(2 * list[i]);
+          list[i] = (exp2x - 1) / (exp2x + 1);
+        }
+      },
+      fallback: (t) {
+        final n = t.numel;
+        for (int i = 0; i < n; i++) {
+          final value = t.storage.getAsDouble(i);
+          final exp2x = math.exp(2 * value);
+          t.storage.setFromDouble(i, (exp2x - 1) / (exp2x + 1));
+        }
+      },
+    );
   }
 
   @override
@@ -210,9 +264,7 @@ class SoftmaxOp extends TransformOp with RequiresContiguous {
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-
-    // Normalize axis
+    // Normalize axis before validation
     final normalizedAxis = axis < 0 ? input.rank + axis : axis;
 
     if (normalizedAxis < 0 || normalizedAxis >= input.rank) {
@@ -224,35 +276,43 @@ class SoftmaxOp extends TransformOp with RequiresContiguous {
       );
     }
 
-    final shape = contiguous.shape;
-    final numel = contiguous.numel;
-    final outputData = Float32List(numel);
+    // Use single-copy pattern
+    final output = cloneForModification(input);
 
-    // Copy input data
-    for (int i = 0; i < numel; i++) {
-      outputData[i] = contiguous.storage.getAsDouble(i).toDouble();
-    }
+    // Compute softmax in-place on output
+    _computeSoftmax(output, normalizedAxis);
 
-    // Compute softmax
-    _computeSoftmax(outputData, shape, normalizedAxis);
-
-    return TensorBuffer(
-      storage: TensorStorage.fromFloat32List(outputData),
-      shape: shape.toList(),
-    );
+    return output;
   }
 
-  void _computeSoftmax(Float32List data, List<int> shape, int axis) {
+  void _computeSoftmax(TensorBuffer tensor, int axis) {
+    final shape = tensor.shape;
+
+    // Dtype-specialized implementation
+    if (tensor.dtype == DType.float32) {
+      _computeSoftmaxFloat32(
+        tensor.storage.data as Float32List,
+        shape,
+        axis,
+      );
+    } else if (tensor.dtype == DType.float64) {
+      _computeSoftmaxFloat64(
+        tensor.storage.data as Float64List,
+        shape,
+        axis,
+      );
+    } else {
+      // Fallback for other types (convert, compute, store back)
+      _computeSoftmaxGeneric(tensor, shape, axis);
+    }
+  }
+
+  void _computeSoftmaxFloat32(Float32List data, List<int> shape, int axis) {
     final rank = shape.length;
     final axisSize = shape[axis];
 
     // Compute strides for iteration
-    final strides = List<int>.filled(rank, 0);
-    int stride = 1;
-    for (int i = rank - 1; i >= 0; i--) {
-      strides[i] = stride;
-      stride *= shape[i];
-    }
+    final strides = TensorIndexer.computeStrides(shape);
 
     // Number of softmax operations to perform
     int numSoftmax = 1;
@@ -295,6 +355,128 @@ class SoftmaxOp extends TransformOp with RequiresContiguous {
           idx += indices[d] * strides[d];
         }
         data[idx] /= sumExp;
+      }
+
+      // Increment indices for non-axis dimensions
+      for (int d = rank - 1; d >= 0; d--) {
+        if (d == axis) continue;
+        indices[d]++;
+        if (indices[d] < shape[d]) break;
+        indices[d] = 0;
+      }
+    }
+  }
+
+  void _computeSoftmaxFloat64(Float64List data, List<int> shape, int axis) {
+    final rank = shape.length;
+    final axisSize = shape[axis];
+
+    // Compute strides for iteration
+    final strides = TensorIndexer.computeStrides(shape);
+
+    // Number of softmax operations to perform
+    int numSoftmax = 1;
+    for (int i = 0; i < rank; i++) {
+      if (i != axis) numSoftmax *= shape[i];
+    }
+
+    // Iterate over all positions except the softmax axis
+    final indices = List<int>.filled(rank, 0);
+    for (int s = 0; s < numSoftmax; s++) {
+      // Find max for numerical stability
+      double maxVal = double.negativeInfinity;
+      for (int a = 0; a < axisSize; a++) {
+        indices[axis] = a;
+        int idx = 0;
+        for (int d = 0; d < rank; d++) {
+          idx += indices[d] * strides[d];
+        }
+        if (data[idx] > maxVal) maxVal = data[idx];
+      }
+
+      // Compute exp(x - max) and sum
+      double sumExp = 0;
+      for (int a = 0; a < axisSize; a++) {
+        indices[axis] = a;
+        int idx = 0;
+        for (int d = 0; d < rank; d++) {
+          idx += indices[d] * strides[d];
+        }
+        final expVal = math.exp(data[idx] - maxVal);
+        data[idx] = expVal;
+        sumExp += expVal;
+      }
+
+      // Normalize
+      for (int a = 0; a < axisSize; a++) {
+        indices[axis] = a;
+        int idx = 0;
+        for (int d = 0; d < rank; d++) {
+          idx += indices[d] * strides[d];
+        }
+        data[idx] /= sumExp;
+      }
+
+      // Increment indices for non-axis dimensions
+      for (int d = rank - 1; d >= 0; d--) {
+        if (d == axis) continue;
+        indices[d]++;
+        if (indices[d] < shape[d]) break;
+        indices[d] = 0;
+      }
+    }
+  }
+
+  void _computeSoftmaxGeneric(TensorBuffer tensor, List<int> shape, int axis) {
+    final rank = shape.length;
+    final axisSize = shape[axis];
+    final storage = tensor.storage;
+
+    // Compute strides for iteration
+    final strides = TensorIndexer.computeStrides(shape);
+
+    // Number of softmax operations to perform
+    int numSoftmax = 1;
+    for (int i = 0; i < rank; i++) {
+      if (i != axis) numSoftmax *= shape[i];
+    }
+
+    // Iterate over all positions except the softmax axis
+    final indices = List<int>.filled(rank, 0);
+    for (int s = 0; s < numSoftmax; s++) {
+      // Find max for numerical stability
+      double maxVal = double.negativeInfinity;
+      for (int a = 0; a < axisSize; a++) {
+        indices[axis] = a;
+        int idx = 0;
+        for (int d = 0; d < rank; d++) {
+          idx += indices[d] * strides[d];
+        }
+        final val = storage.getAsDouble(idx);
+        if (val > maxVal) maxVal = val;
+      }
+
+      // Compute exp(x - max) and sum
+      double sumExp = 0;
+      for (int a = 0; a < axisSize; a++) {
+        indices[axis] = a;
+        int idx = 0;
+        for (int d = 0; d < rank; d++) {
+          idx += indices[d] * strides[d];
+        }
+        final expVal = math.exp(storage.getAsDouble(idx) - maxVal);
+        storage.setFromDouble(idx, expVal);
+        sumExp += expVal;
+      }
+
+      // Normalize
+      for (int a = 0; a < axisSize; a++) {
+        indices[axis] = a;
+        int idx = 0;
+        for (int d = 0; d < rank; d++) {
+          idx += indices[d] * strides[d];
+        }
+        storage.setFromDouble(idx, storage.getAsDouble(idx) / sumExp);
       }
 
       // Increment indices for non-axis dimensions

--- a/lib/src/ops/math_op.dart
+++ b/lib/src/ops/math_op.dart
@@ -14,8 +14,7 @@ abstract class UnaryMathOp extends TransformOp
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-    final output = contiguous.clone();
+    final output = cloneForModification(input);
     _apply(output);
     return output;
   }

--- a/lib/src/ops/normalize_op.dart
+++ b/lib/src/ops/normalize_op.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
 import '../exceptions/tensor_exceptions.dart';
+import '../utils/dtype_dispatcher.dart';
 import 'transform_op.dart';
 
 /// Normalizes tensor values per channel using mean and standard deviation.
@@ -72,10 +73,8 @@ class NormalizeOp extends TransformOp
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-    _validateShape(contiguous.shape);
-
-    final output = contiguous.clone();
+    _validateShape(input.shape);
+    final output = cloneForModification(input);
     _normalize(output);
     return output;
   }
@@ -257,9 +256,7 @@ class ScaleOp extends TransformOp with InPlaceTransform, RequiresContiguous {
 
   @override
   TensorBuffer apply(TensorBuffer input) {
-    final contiguous = ensureContiguous(input);
-
-    final output = contiguous.clone();
+    final output = cloneForModification(input);
     _scale(output);
     return output;
   }
@@ -273,28 +270,28 @@ class ScaleOp extends TransformOp with InPlaceTransform, RequiresContiguous {
   }
 
   void _scale(TensorBuffer tensor) {
-    final numel = tensor.numel;
-    final data = tensor.storage.data;
-
-    // Dtype-specialized loop to avoid per-element switch overhead
-    switch (tensor.dtype) {
-      case DType.float32:
-        final list = data as Float32List;
+    final s = scale;
+    final o = offset;
+    DTypeDispatcher.dispatchVoid(
+      tensor,
+      onFloat32: (list, numel) {
         for (int i = 0; i < numel; i++) {
-          list[i] = (list[i] - offset) / scale;
+          list[i] = (list[i] - o) / s;
         }
-      case DType.float64:
-        final list = data as Float64List;
+      },
+      onFloat64: (list, numel) {
         for (int i = 0; i < numel; i++) {
-          list[i] = (list[i] - offset) / scale;
+          list[i] = (list[i] - o) / s;
         }
-      default:
-        // Fallback for integer types
-        for (int i = 0; i < numel; i++) {
-          final value = tensor.storage.getAsDouble(i);
-          tensor.storage.setFromDouble(i, (value - offset) / scale);
+      },
+      fallback: (t) {
+        final n = t.numel;
+        for (int i = 0; i < n; i++) {
+          final value = t.storage.getAsDouble(i);
+          t.storage.setFromDouble(i, (value - o) / s);
         }
-    }
+      },
+    );
   }
 
   @override

--- a/lib/src/ops/transform_op.dart
+++ b/lib/src/ops/transform_op.dart
@@ -40,6 +40,27 @@ mixin RequiresContiguous on TransformOp {
     }
     return input;
   }
+
+  /// Creates an output buffer from input, ensuring contiguity with single copy.
+  ///
+  /// If input is contiguous, clones it. Otherwise, creates contiguous copy.
+  /// This avoids the double-copy pattern of `ensureContiguous() + clone()`.
+  ///
+  /// Use this when you need a contiguous output buffer that will be modified
+  /// in place, without affecting the original input.
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// TensorBuffer apply(TensorBuffer input) {
+  ///   final output = cloneForModification(input);
+  ///   _modifyInPlace(output);
+  ///   return output;
+  /// }
+  /// ```
+  TensorBuffer cloneForModification(TensorBuffer input) {
+    return input.isContiguous ? input.clone() : input.contiguous();
+  }
 }
 
 /// A no-op transform that returns the input unchanged.

--- a/lib/src/utils/dtype_dispatcher.dart
+++ b/lib/src/utils/dtype_dispatcher.dart
@@ -1,0 +1,119 @@
+/// Utility for dispatching operations based on tensor dtype.
+///
+/// Eliminates repetitive dtype switch statements by providing typed callbacks.
+/// This reduces code duplication and ensures consistent dtype handling across
+/// the codebase.
+library;
+
+import 'dart:typed_data';
+
+import '../core/dtype.dart';
+import '../core/tensor_buffer.dart';
+
+/// Utility for dispatching operations based on tensor dtype.
+///
+/// The dtype switch pattern appears 15+ times across the codebase.
+/// This utility centralizes that logic for consistency and maintainability.
+///
+/// Example usage:
+/// ```dart
+/// void relu(TensorBuffer tensor) {
+///   DTypeDispatcher.dispatchVoid(
+///     tensor,
+///     onFloat32: (list, numel) {
+///       for (int i = 0; i < numel; i++) {
+///         if (list[i] < 0) list[i] = 0;
+///       }
+///     },
+///     onFloat64: (list, numel) {
+///       for (int i = 0; i < numel; i++) {
+///         if (list[i] < 0) list[i] = 0;
+///       }
+///     },
+///     fallback: (tensor) {
+///       for (int i = 0; i < tensor.numel; i++) {
+///         final value = tensor.storage.getAsDouble(i);
+///         if (value < 0) tensor.storage.setFromDouble(i, 0.0);
+///       }
+///     },
+///   );
+/// }
+/// ```
+class DTypeDispatcher {
+  DTypeDispatcher._();
+
+  /// Dispatches to typed callback based on tensor dtype.
+  ///
+  /// Returns result from the appropriate callback:
+  /// - [onFloat32] for Float32 tensors
+  /// - [onFloat64] for Float64 tensors
+  /// - [fallback] for all other types
+  static R dispatch<R>(
+    TensorBuffer tensor, {
+    required R Function(Float32List data, int numel) onFloat32,
+    required R Function(Float64List data, int numel) onFloat64,
+    required R Function(TensorBuffer tensor) fallback,
+  }) {
+    final numel = tensor.numel;
+    switch (tensor.dtype) {
+      case DType.float32:
+        return onFloat32(tensor.storage.data as Float32List, numel);
+      case DType.float64:
+        return onFloat64(tensor.storage.data as Float64List, numel);
+      default:
+        return fallback(tensor);
+    }
+  }
+
+  /// Dispatches void operations (in-place modifications).
+  ///
+  /// Convenience method for operations that don't return a value.
+  static void dispatchVoid(
+    TensorBuffer tensor, {
+    required void Function(Float32List data, int numel) onFloat32,
+    required void Function(Float64List data, int numel) onFloat64,
+    required void Function(TensorBuffer tensor) fallback,
+  }) {
+    dispatch<void>(
+      tensor,
+      onFloat32: onFloat32,
+      onFloat64: onFloat64,
+      fallback: fallback,
+    );
+  }
+
+  /// Pair dispatch for operations involving two tensors.
+  ///
+  /// Used when input and output tensors are separate (e.g., normalization).
+  /// Falls back to generic handling if dtypes don't match.
+  static R dispatchPair<R>(
+    TensorBuffer input,
+    TensorBuffer output, {
+    required R Function(Float32List inData, Float32List outData, int numel)
+        onFloat32,
+    required R Function(Float64List inData, Float64List outData, int numel)
+        onFloat64,
+    required R Function(TensorBuffer input, TensorBuffer output) fallback,
+  }) {
+    if (input.dtype != output.dtype) {
+      return fallback(input, output);
+    }
+    final numel = input.numel;
+    switch (input.dtype) {
+      case DType.float32:
+        return onFloat32(
+          input.storage.data as Float32List,
+          output.storage.data as Float32List,
+          numel,
+        );
+      case DType.float64:
+        return onFloat64(
+          input.storage.data as Float64List,
+          output.storage.data as Float64List,
+          numel,
+        );
+      default:
+        return fallback(input, output);
+    }
+  }
+}

--- a/lib/src/utils/tensor_indexing.dart
+++ b/lib/src/utils/tensor_indexing.dart
@@ -1,0 +1,124 @@
+/// Utilities for tensor index calculations.
+///
+/// Provides optimized index computation methods commonly used in tensor
+/// operations like resize, pad, and convolution.
+library;
+
+/// Utilities for tensor index calculations.
+///
+/// These methods encapsulate common index patterns found throughout the
+/// codebase, reducing duplication and potential for errors.
+///
+/// For hot paths (inner loops), consider using inline expressions or
+/// `@pragma('vm:prefer-inline')` annotated methods for best performance.
+class TensorIndexer {
+  TensorIndexer._();
+
+  /// Computes linear index for 4D tensor [N,C,H,W] (NCHW format).
+  ///
+  /// This is the most common layout for image tensors in PyTorch and ONNX.
+  ///
+  /// Example:
+  /// ```dart
+  /// // For tensor of shape [2, 3, 4, 5] (N=2, C=3, H=4, W=5)
+  /// final idx = TensorIndexer.index4D(1, 2, 3, 4, 3, 4, 5);
+  /// // idx = 1*60 + 2*20 + 3*5 + 4 = 60 + 40 + 15 + 4 = 119
+  /// ```
+  @pragma('vm:prefer-inline')
+  static int index4D(int b, int c, int h, int w, int C, int H, int W) {
+    return ((b * C + c) * H + h) * W + w;
+  }
+
+  /// Computes linear index for 3D tensor [C,H,W].
+  ///
+  /// Used for single-image processing without batch dimension.
+  @pragma('vm:prefer-inline')
+  static int index3D(int c, int h, int w, int H, int W) {
+    return (c * H + h) * W + w;
+  }
+
+  /// Computes linear index for 2D tensor [H,W].
+  ///
+  /// Used for grayscale images or single-channel operations.
+  @pragma('vm:prefer-inline')
+  static int index2D(int h, int w, int W) {
+    return h * W + w;
+  }
+
+  /// Converts linear index to multi-dimensional coordinates.
+  ///
+  /// Given a flat index into contiguous storage, returns the corresponding
+  /// multi-dimensional coordinates for the given shape.
+  ///
+  /// Example:
+  /// ```dart
+  /// final coords = TensorIndexer.linearToCoords(11, [2, 3, 2]);
+  /// // 11 = 1*6 + 1*2 + 1 → coords = [1, 2, 1]
+  /// ```
+  static List<int> linearToCoords(int linearIdx, List<int> shape) {
+    final rank = shape.length;
+    final coords = List<int>.filled(rank, 0);
+    int remaining = linearIdx;
+
+    for (int d = rank - 1; d >= 0; d--) {
+      coords[d] = remaining % shape[d];
+      remaining ~/= shape[d];
+    }
+
+    return coords;
+  }
+
+  /// Converts multi-dimensional coordinates to linear index using strides.
+  ///
+  /// For non-contiguous tensors (e.g., transposed), use the tensor's
+  /// actual strides rather than computing from shape.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Contiguous tensor of shape [2, 3, 4] has strides [12, 4, 1]
+  /// final idx = TensorIndexer.coordsToLinear([1, 2, 3], [12, 4, 1]);
+  /// // idx = 1*12 + 2*4 + 3*1 = 23
+  /// ```
+  @pragma('vm:prefer-inline')
+  static int coordsToLinear(List<int> coords, List<int> strides) {
+    int offset = 0;
+    for (int d = 0; d < coords.length; d++) {
+      offset += coords[d] * strides[d];
+    }
+    return offset;
+  }
+
+  /// Pre-computes contiguous strides for a shape.
+  ///
+  /// Returns row-major (C-order) strides where the last dimension
+  /// has stride 1.
+  ///
+  /// Example:
+  /// ```dart
+  /// final strides = TensorIndexer.computeStrides([2, 3, 4]);
+  /// // strides = [12, 4, 1]
+  /// ```
+  static List<int> computeStrides(List<int> shape) {
+    final rank = shape.length;
+    if (rank == 0) return [];
+    final strides = List<int>.filled(rank, 1);
+    for (int i = rank - 2; i >= 0; i--) {
+      strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    return strides;
+  }
+
+  /// Computes linear index for 4D tensor in NHWC format.
+  ///
+  /// This layout is common in TensorFlow and Flutter's image library.
+  @pragma('vm:prefer-inline')
+  static int index4DNHWC(int b, int h, int w, int c, int H, int W, int C) {
+    return ((b * H + h) * W + w) * C + c;
+  }
+
+  /// Computes linear index for 3D tensor in HWC format.
+  @pragma('vm:prefer-inline')
+  static int index3DHWC(int h, int w, int c, int W, int C) {
+    return (h * W + w) * C + c;
+  }
+}

--- a/lib/src/utils/typed_data_views.dart
+++ b/lib/src/utils/typed_data_views.dart
@@ -1,0 +1,239 @@
+import 'dart:typed_data';
+
+import '../core/dtype.dart';
+import '../core/memory_format.dart';
+import '../core/tensor_buffer.dart';
+
+/// Utilities for working with TypedData views and zero-copy operations.
+///
+/// These utilities help determine when tensor operations can use views
+/// instead of copying data, and provide efficient view creation methods.
+class TypedDataViews {
+  TypedDataViews._();
+
+  /// Creates a sublist view of a Float32List without copying.
+  ///
+  /// This is a zero-copy operation that returns a view into the original data.
+  static Float32List float32SublistView(Float32List data, int start,
+      [int? end]) {
+    return Float32List.sublistView(data, start, end);
+  }
+
+  /// Creates a sublist view of a Float64List without copying.
+  static Float64List float64SublistView(Float64List data, int start,
+      [int? end]) {
+    return Float64List.sublistView(data, start, end);
+  }
+
+  /// Creates a sublist view of an Int32List without copying.
+  static Int32List int32SublistView(Int32List data, int start, [int? end]) {
+    return Int32List.sublistView(data, start, end);
+  }
+
+  /// Creates a sublist view of a Uint8List without copying.
+  static Uint8List uint8SublistView(Uint8List data, int start, [int? end]) {
+    return Uint8List.sublistView(data, start, end);
+  }
+
+  /// Creates a typed view from a ByteBuffer at a specific offset.
+  ///
+  /// This allows reinterpreting bytes as different types without copying.
+  static TypedData viewAs(
+    ByteBuffer buffer,
+    DType dtype, {
+    int offsetInBytes = 0,
+    int? length,
+  }) {
+    switch (dtype) {
+      case DType.float32:
+        return buffer.asFloat32List(offsetInBytes, length);
+      case DType.float64:
+        return buffer.asFloat64List(offsetInBytes, length);
+      case DType.int8:
+        return buffer.asInt8List(offsetInBytes, length);
+      case DType.int16:
+        return buffer.asInt16List(offsetInBytes, length);
+      case DType.int32:
+        return buffer.asInt32List(offsetInBytes, length);
+      case DType.int64:
+        return buffer.asInt64List(offsetInBytes, length);
+      case DType.uint8:
+        return buffer.asUint8List(offsetInBytes, length);
+      case DType.uint16:
+        return buffer.asUint16List(offsetInBytes, length);
+      case DType.uint32:
+        return buffer.asUint32List(offsetInBytes, length);
+      case DType.uint64:
+        return buffer.asUint64List(offsetInBytes, length);
+    }
+  }
+}
+
+/// Extension methods for creating tensor views efficiently.
+extension TensorViewExtension on TensorBuffer {
+  /// Creates a view of a contiguous slice along the first dimension.
+  ///
+  /// This is a zero-copy operation when possible. Returns a view into
+  /// the same underlying storage with adjusted offset and shape.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.zeros([10, 224, 224], dtype: DType.float32);
+  /// final batch = tensor.sliceFirst(2, 5); // Elements 2..4 along dim 0
+  /// // batch.shape is [3, 224, 224], shares storage with tensor
+  /// ```
+  ///
+  /// Throws if the tensor is not contiguous.
+  TensorBuffer sliceFirst(int start, int end) {
+    if (!isContiguous) {
+      throw StateError('sliceFirst requires contiguous tensor');
+    }
+    if (start < 0 || end > shape[0] || start >= end) {
+      throw RangeError('Invalid slice range: [$start, $end) for shape $shape');
+    }
+
+    final newShape = [end - start, ...shape.skip(1)];
+    final elementsPerSlice = shape.skip(1).fold(1, (a, b) => a * b);
+    final newOffset = storageOffset + start * elementsPerSlice;
+
+    return TensorBuffer(
+      storage: storage,
+      shape: newShape,
+      storageOffset: newOffset,
+      memoryFormat: memoryFormat,
+    );
+  }
+
+  /// Checks if this tensor can be represented as a contiguous view
+  /// of another tensor's storage.
+  ///
+  /// This is useful for determining whether operations can avoid copying.
+  bool get isViewable => isContiguous && storageOffset == 0;
+
+  /// Returns a view with channels moved to a different position.
+  ///
+  /// For a 4D NCHW tensor, converts to NHWC format without copying
+  /// by adjusting strides.
+  TensorBuffer toChannelsLast() {
+    if (rank != 4) {
+      throw StateError('toChannelsLast only supports 4D tensors');
+    }
+    // NCHW -> NHWC via transpose
+    return transpose([0, 2, 3, 1]);
+  }
+
+  /// For a 4D NHWC tensor, converts to NCHW format without copying.
+  TensorBuffer toChannelsFirst() {
+    if (rank != 4) {
+      throw StateError('toChannelsFirst only supports 4D tensors');
+    }
+    // NHWC -> NCHW via transpose
+    return transpose([0, 3, 1, 2]);
+  }
+
+  /// Creates a flat view of this tensor.
+  ///
+  /// Returns a 1D tensor sharing the same storage.
+  /// Throws if the tensor is not contiguous.
+  TensorBuffer flatten() {
+    if (!isContiguous) {
+      throw StateError('flatten requires contiguous tensor');
+    }
+    return reshape([numel]);
+  }
+
+  /// Splits the tensor along a dimension into multiple views.
+  ///
+  /// Returns a list of tensors, each sharing storage with the original.
+  /// This is useful for batch processing.
+  ///
+  /// ```dart
+  /// final batch = TensorBuffer.zeros([8, 3, 224, 224]);
+  /// final items = batch.unbind(0); // 8 tensors of shape [3, 224, 224]
+  /// ```
+  List<TensorBuffer> unbind(int dim) {
+    if (dim < 0 || dim >= rank) {
+      throw RangeError('dim $dim out of range for rank $rank');
+    }
+
+    final results = <TensorBuffer>[];
+    final dimSize = shape[dim];
+
+    for (int i = 0; i < dimSize; i++) {
+      // Create a view for each index along dim
+      final newShape = [...shape]..removeAt(dim);
+      final newStrides = [...strides]..removeAt(dim);
+
+      // Calculate offset for this slice
+      final sliceOffset = storageOffset + i * strides[dim];
+
+      results.add(TensorBuffer(
+        storage: storage,
+        shape: newShape,
+        strides: newStrides,
+        storageOffset: sliceOffset,
+        memoryFormat: MemoryFormat.contiguous,
+      ));
+    }
+
+    return results;
+  }
+
+  /// Selects a single index along a dimension, returning a view with
+  /// reduced rank.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.zeros([10, 3, 224, 224]);
+  /// final first = tensor.select(0, 0); // shape [3, 224, 224]
+  /// ```
+  TensorBuffer select(int dim, int index) {
+    if (dim < 0 || dim >= rank) {
+      throw RangeError('dim $dim out of range for rank $rank');
+    }
+    if (index < 0 || index >= shape[dim]) {
+      throw RangeError('index $index out of range for dim $dim size ${shape[dim]}');
+    }
+
+    final newShape = [...shape]..removeAt(dim);
+    final newStrides = [...strides]..removeAt(dim);
+    final newOffset = storageOffset + index * strides[dim];
+
+    return TensorBuffer(
+      storage: storage,
+      shape: newShape,
+      strides: newStrides,
+      storageOffset: newOffset,
+      memoryFormat: memoryFormat,
+    );
+  }
+
+  /// Narrows the tensor along a dimension.
+  ///
+  /// Creates a view that only includes elements from [start] to [start + length)
+  /// along the specified dimension.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.zeros([10, 224, 224]);
+  /// final narrowed = tensor.narrow(0, 2, 5); // shape [5, 224, 224]
+  /// ```
+  TensorBuffer narrow(int dim, int start, int length) {
+    if (dim < 0 || dim >= rank) {
+      throw RangeError('dim $dim out of range for rank $rank');
+    }
+    if (start < 0 || start + length > shape[dim]) {
+      throw RangeError('Invalid narrow range: start=$start, length=$length, dim size=${shape[dim]}');
+    }
+
+    final newShape = [...shape];
+    newShape[dim] = length;
+
+    final newOffset = storageOffset + start * strides[dim];
+
+    return TensorBuffer(
+      storage: storage,
+      shape: newShape,
+      strides: strides,
+      storageOffset: newOffset,
+      memoryFormat: memoryFormat,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tensor_preprocessing
 description: >-
   High-performance tensor preprocessing library for Flutter/Dart.
   NumPy-like transforms pipeline for ONNX Runtime inference.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/brody-0125/dart_tensor_preprocessing
 homepage: https://github.com/brody-0125/dart_tensor_preprocessing
 

--- a/test/buffer_pool_test.dart
+++ b/test/buffer_pool_test.dart
@@ -1,0 +1,185 @@
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BufferPool', () {
+    late BufferPool pool;
+
+    setUp(() {
+      pool = BufferPool.create();
+    });
+
+    group('acquire', () {
+      test('allocates new buffer when pool is empty', () {
+        final buffer = pool.acquireFloat32(100);
+
+        expect(buffer, isA<Float32List>());
+        expect(buffer.length, greaterThanOrEqualTo(100));
+      });
+
+      test('rounds up to power of 2 bucket size', () {
+        final buffer = pool.acquireFloat32(100);
+
+        // 100 rounds up to 128
+        expect(buffer.length, equals(128));
+      });
+
+      test('returns pooled buffer when available', () {
+        final original = pool.acquireFloat32(100);
+        pool.release(original);
+
+        final reused = pool.acquireFloat32(100);
+
+        expect(identical(reused, original), isTrue);
+      });
+
+      test('handles different dtypes separately', () {
+        final float32 = pool.acquireFloat32(100);
+        pool.release(float32);
+
+        final float64 = pool.acquireFloat64(100);
+
+        expect(float64, isA<Float64List>());
+        expect(identical(float64, float32), isFalse);
+      });
+
+      test('handles different sizes separately', () {
+        final small = pool.acquireFloat32(64);
+        pool.release(small);
+
+        final large = pool.acquireFloat32(256);
+
+        expect(identical(large, small), isFalse);
+        expect(large.length, equals(256));
+      });
+    });
+
+    group('release', () {
+      test('adds buffer to pool', () {
+        expect(pool.pooledCount, equals(0));
+
+        final buffer = pool.acquire(100, DType.float32);
+        pool.release(buffer);
+
+        expect(pool.pooledCount, equals(1));
+      });
+
+      test('respects maxBuffersPerBucket limit', () {
+        final buffers = <TypedData>[];
+        for (int i = 0; i < BufferPool.maxBuffersPerBucket + 5; i++) {
+          buffers.add(pool.acquire(100, DType.float32));
+        }
+
+        for (final buffer in buffers) {
+          pool.release(buffer);
+        }
+
+        expect(pool.pooledCount, equals(BufferPool.maxBuffersPerBucket));
+      });
+    });
+
+    group('clear', () {
+      test('removes all pooled buffers', () {
+        final buffer1 = pool.acquire(100, DType.float32);
+        final buffer2 = pool.acquire(100, DType.float64);
+        pool.release(buffer1);
+        pool.release(buffer2);
+
+        expect(pool.pooledCount, equals(2));
+
+        pool.clear();
+
+        expect(pool.pooledCount, equals(0));
+      });
+    });
+
+    group('pooledCount', () {
+      test('returns correct count across dtypes and sizes', () {
+        final b1 = pool.acquire(64, DType.float32);
+        final b2 = pool.acquire(128, DType.float32);
+        final b3 = pool.acquire(64, DType.float64);
+
+        pool.release(b1);
+        pool.release(b2);
+        pool.release(b3);
+
+        expect(pool.pooledCount, equals(3));
+      });
+    });
+
+    group('pooledBytes', () {
+      test('returns correct total bytes', () {
+        final b1 = pool.acquire(64, DType.float32); // 64 * 4 = 256 bytes
+        final b2 = pool.acquire(32, DType.float64); // 32 * 8 = 256 bytes
+
+        pool.release(b1);
+        pool.release(b2);
+
+        expect(pool.pooledBytes, equals(512));
+      });
+    });
+
+    group('singleton', () {
+      test('instance returns same pool', () {
+        final pool1 = BufferPool.instance;
+        final pool2 = BufferPool.instance;
+
+        expect(identical(pool1, pool2), isTrue);
+      });
+    });
+
+    group('BufferPoolExtension', () {
+      test('acquireFloat32 returns Float32List', () {
+        final buffer = pool.acquireFloat32(100);
+
+        expect(buffer, isA<Float32List>());
+      });
+
+      test('acquireFloat64 returns Float64List', () {
+        final buffer = pool.acquireFloat64(100);
+
+        expect(buffer, isA<Float64List>());
+      });
+
+      test('acquireUint8 returns Uint8List', () {
+        final buffer = pool.acquireUint8(100);
+
+        expect(buffer, isA<Uint8List>());
+      });
+
+      test('acquireInt32 returns Int32List', () {
+        final buffer = pool.acquireInt32(100);
+
+        expect(buffer, isA<Int32List>());
+      });
+    });
+
+    group('bucket sizing', () {
+      test('size 0 returns bucket size 1', () {
+        final buffer = pool.acquireFloat32(0);
+
+        expect(buffer.length, equals(1));
+      });
+
+      test('size 1 returns bucket size 1', () {
+        final buffer = pool.acquireFloat32(1);
+
+        expect(buffer.length, equals(1));
+      });
+
+      test('exact power of 2 returns same size', () {
+        final buffer = pool.acquireFloat32(256);
+
+        expect(buffer.length, equals(256));
+      });
+
+      test('size 257 returns bucket size 512', () {
+        final buffer = pool.acquireFloat32(257);
+
+        expect(buffer.length, equals(512));
+      });
+    });
+  });
+}

--- a/test/dtype_dispatcher_test.dart
+++ b/test/dtype_dispatcher_test.dart
@@ -1,0 +1,307 @@
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DTypeDispatcher', () {
+    group('dispatch', () {
+      test('calls onFloat32 for float32 tensor', () {
+        final tensor = TensorBuffer.zeros([2, 2], dtype: DType.float32);
+        String called = '';
+
+        final result = DTypeDispatcher.dispatch<String>(
+          tensor,
+          onFloat32: (data, numel) {
+            called = 'float32';
+            expect(data, isA<Float32List>());
+            expect(numel, 4);
+            return 'float32-result';
+          },
+          onFloat64: (data, numel) {
+            called = 'float64';
+            return 'float64-result';
+          },
+          fallback: (t) {
+            called = 'fallback';
+            return 'fallback-result';
+          },
+        );
+
+        expect(called, 'float32');
+        expect(result, 'float32-result');
+      });
+
+      test('calls onFloat64 for float64 tensor', () {
+        final tensor = TensorBuffer.zeros([2, 3], dtype: DType.float64);
+        String called = '';
+
+        final result = DTypeDispatcher.dispatch<String>(
+          tensor,
+          onFloat32: (data, numel) {
+            called = 'float32';
+            return 'float32-result';
+          },
+          onFloat64: (data, numel) {
+            called = 'float64';
+            expect(data, isA<Float64List>());
+            expect(numel, 6);
+            return 'float64-result';
+          },
+          fallback: (t) {
+            called = 'fallback';
+            return 'fallback-result';
+          },
+        );
+
+        expect(called, 'float64');
+        expect(result, 'float64-result');
+      });
+
+      test('calls fallback for int64 tensor', () {
+        final tensor = TensorBuffer.zeros([2, 2], dtype: DType.int64);
+        String called = '';
+
+        final result = DTypeDispatcher.dispatch<String>(
+          tensor,
+          onFloat32: (data, numel) {
+            called = 'float32';
+            return 'float32-result';
+          },
+          onFloat64: (data, numel) {
+            called = 'float64';
+            return 'float64-result';
+          },
+          fallback: (t) {
+            called = 'fallback';
+            expect(t.numel, 4);
+            return 'fallback-result';
+          },
+        );
+
+        expect(called, 'fallback');
+        expect(result, 'fallback-result');
+      });
+
+      test('returns computed value from callback', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, 2.0, 3.0, 4.0]),
+          [4],
+        );
+
+        final sum = DTypeDispatcher.dispatch<double>(
+          tensor,
+          onFloat32: (data, numel) {
+            double s = 0;
+            for (int i = 0; i < numel; i++) {
+              s += data[i];
+            }
+            return s;
+          },
+          onFloat64: (data, numel) {
+            double s = 0;
+            for (int i = 0; i < numel; i++) {
+              s += data[i];
+            }
+            return s;
+          },
+          fallback: (t) => 0.0,
+        );
+
+        expect(sum, 10.0);
+      });
+    });
+
+    group('dispatchVoid', () {
+      test('modifies float32 tensor in-place', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, -2.0, 3.0, -4.0]),
+          [4],
+        );
+
+        DTypeDispatcher.dispatchVoid(
+          tensor,
+          onFloat32: (data, numel) {
+            for (int i = 0; i < numel; i++) {
+              if (data[i] < 0) data[i] = 0;
+            }
+          },
+          onFloat64: (data, numel) {
+            for (int i = 0; i < numel; i++) {
+              if (data[i] < 0) data[i] = 0;
+            }
+          },
+          fallback: (t) {
+            for (int i = 0; i < t.numel; i++) {
+              final v = t.storage.getAsDouble(i);
+              if (v < 0) t.storage.setFromDouble(i, 0);
+            }
+          },
+        );
+
+        expect(tensor.toList(), [1.0, 0.0, 3.0, 0.0]);
+      });
+
+      test('modifies float64 tensor in-place', () {
+        final tensor = TensorBuffer.fromFloat64List(
+          Float64List.fromList([1.0, -2.0, 3.0, -4.0]),
+          [4],
+        );
+
+        DTypeDispatcher.dispatchVoid(
+          tensor,
+          onFloat32: (data, numel) {
+            for (int i = 0; i < numel; i++) {
+              if (data[i] < 0) data[i] = 0;
+            }
+          },
+          onFloat64: (data, numel) {
+            for (int i = 0; i < numel; i++) {
+              if (data[i] < 0) data[i] = 0;
+            }
+          },
+          fallback: (t) {
+            for (int i = 0; i < t.numel; i++) {
+              final v = t.storage.getAsDouble(i);
+              if (v < 0) t.storage.setFromDouble(i, 0);
+            }
+          },
+        );
+
+        expect(tensor.toList(), [1.0, 0.0, 3.0, 0.0]);
+      });
+    });
+
+    group('dispatchPair', () {
+      test('handles matching float32 dtypes', () {
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, 2.0, 3.0, 4.0]),
+          [4],
+        );
+        final output = TensorBuffer.zeros([4], dtype: DType.float32);
+        String called = '';
+
+        DTypeDispatcher.dispatchPair<void>(
+          input,
+          output,
+          onFloat32: (inData, outData, numel) {
+            called = 'float32';
+            for (int i = 0; i < numel; i++) {
+              outData[i] = inData[i] * 2;
+            }
+          },
+          onFloat64: (inData, outData, numel) {
+            called = 'float64';
+          },
+          fallback: (inp, out) {
+            called = 'fallback';
+          },
+        );
+
+        expect(called, 'float32');
+        expect(output.toList(), [2.0, 4.0, 6.0, 8.0]);
+      });
+
+      test('handles matching float64 dtypes', () {
+        final input = TensorBuffer.fromFloat64List(
+          Float64List.fromList([1.0, 2.0, 3.0, 4.0]),
+          [4],
+        );
+        final output = TensorBuffer.zeros([4], dtype: DType.float64);
+        String called = '';
+
+        DTypeDispatcher.dispatchPair<void>(
+          input,
+          output,
+          onFloat32: (inData, outData, numel) {
+            called = 'float32';
+          },
+          onFloat64: (inData, outData, numel) {
+            called = 'float64';
+            for (int i = 0; i < numel; i++) {
+              outData[i] = inData[i] * 3;
+            }
+          },
+          fallback: (inp, out) {
+            called = 'fallback';
+          },
+        );
+
+        expect(called, 'float64');
+        expect(output.toList(), [3.0, 6.0, 9.0, 12.0]);
+      });
+
+      test('falls back on dtype mismatch', () {
+        final input = TensorBuffer.zeros([4], dtype: DType.float32);
+        final output = TensorBuffer.zeros([4], dtype: DType.float64);
+        String called = '';
+
+        DTypeDispatcher.dispatchPair<void>(
+          input,
+          output,
+          onFloat32: (inData, outData, numel) {
+            called = 'float32';
+          },
+          onFloat64: (inData, outData, numel) {
+            called = 'float64';
+          },
+          fallback: (inp, out) {
+            called = 'fallback';
+            expect(inp.dtype, DType.float32);
+            expect(out.dtype, DType.float64);
+          },
+        );
+
+        expect(called, 'fallback');
+      });
+
+      test('falls back for non-float dtypes', () {
+        final input = TensorBuffer.zeros([4], dtype: DType.int32);
+        final output = TensorBuffer.zeros([4], dtype: DType.int32);
+        String called = '';
+
+        DTypeDispatcher.dispatchPair<void>(
+          input,
+          output,
+          onFloat32: (inData, outData, numel) {
+            called = 'float32';
+          },
+          onFloat64: (inData, outData, numel) {
+            called = 'float64';
+          },
+          fallback: (inp, out) {
+            called = 'fallback';
+          },
+        );
+
+        expect(called, 'fallback');
+      });
+
+      test('returns value from pair dispatch', () {
+        final input = TensorBuffer.fromFloat32List(
+          Float32List.fromList([1.0, 2.0, 3.0]),
+          [3],
+        );
+        final output = TensorBuffer.zeros([3], dtype: DType.float32);
+
+        final result = DTypeDispatcher.dispatchPair<double>(
+          input,
+          output,
+          onFloat32: (inData, outData, numel) {
+            double sum = 0;
+            for (int i = 0; i < numel; i++) {
+              outData[i] = inData[i] * 2;
+              sum += outData[i];
+            }
+            return sum;
+          },
+          onFloat64: (inData, outData, numel) => 0.0,
+          fallback: (inp, out) => -1.0,
+        );
+
+        expect(result, 12.0); // 2 + 4 + 6
+        expect(output.toList(), [2.0, 4.0, 6.0]);
+      });
+    });
+  });
+}

--- a/test/tensor_indexing_test.dart
+++ b/test/tensor_indexing_test.dart
@@ -1,0 +1,212 @@
+import 'package:dart_tensor_preprocessing/src/utils/tensor_indexing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TensorIndexer', () {
+    group('index4D', () {
+      test('computes correct index for NCHW tensor', () {
+        // Shape [2, 3, 4, 5] → strides [60, 20, 5, 1]
+        // Element at [1, 2, 3, 4]
+        const C = 3, H = 4, W = 5;
+        final idx = TensorIndexer.index4D(1, 2, 3, 4, C, H, W);
+
+        // Manual: 1*60 + 2*20 + 3*5 + 4 = 60 + 40 + 15 + 4 = 119
+        expect(idx, 119);
+      });
+
+      test('index at origin is 0', () {
+        final idx = TensorIndexer.index4D(0, 0, 0, 0, 3, 4, 5);
+        expect(idx, 0);
+      });
+
+      test('index at last position is numel-1', () {
+        const N = 2, C = 3, H = 4, W = 5;
+        final idx = TensorIndexer.index4D(N - 1, C - 1, H - 1, W - 1, C, H, W);
+        expect(idx, N * C * H * W - 1);
+      });
+    });
+
+    group('index3D', () {
+      test('computes correct index for CHW tensor', () {
+        // Shape [3, 4, 5] → strides [20, 5, 1]
+        const H = 4, W = 5;
+        final idx = TensorIndexer.index3D(2, 3, 4, H, W);
+
+        // Manual: 2*20 + 3*5 + 4 = 40 + 15 + 4 = 59
+        expect(idx, 59);
+      });
+    });
+
+    group('index2D', () {
+      test('computes correct index for HW tensor', () {
+        const W = 5;
+        final idx = TensorIndexer.index2D(3, 4, W);
+
+        // Manual: 3*5 + 4 = 19
+        expect(idx, 19);
+      });
+
+      test('handles single row', () {
+        expect(TensorIndexer.index2D(0, 3, 10), 3);
+      });
+
+      test('handles single column', () {
+        expect(TensorIndexer.index2D(5, 0, 1), 5);
+      });
+    });
+
+    group('linearToCoords', () {
+      test('converts linear index to 3D coords', () {
+        // Shape [2, 3, 4], strides [12, 4, 1]
+        // Index 15 = 1*12 + 0*4 + 3 → [1, 0, 3]
+        final coords = TensorIndexer.linearToCoords(15, [2, 3, 4]);
+        expect(coords, [1, 0, 3]);
+      });
+
+      test('handles index 0', () {
+        final coords = TensorIndexer.linearToCoords(0, [2, 3, 4]);
+        expect(coords, [0, 0, 0]);
+      });
+
+      test('handles last index', () {
+        // Shape [2, 3, 4], numel = 24, last = 23
+        // 23 = 1*12 + 2*4 + 3 → [1, 2, 3]
+        final coords = TensorIndexer.linearToCoords(23, [2, 3, 4]);
+        expect(coords, [1, 2, 3]);
+      });
+
+      test('handles 1D shape', () {
+        final coords = TensorIndexer.linearToCoords(5, [10]);
+        expect(coords, [5]);
+      });
+
+      test('handles 4D shape', () {
+        // Shape [2, 3, 4, 5], strides [60, 20, 5, 1]
+        // Index 119 = 1*60 + 2*20 + 3*5 + 4 → [1, 2, 3, 4]
+        final coords = TensorIndexer.linearToCoords(119, [2, 3, 4, 5]);
+        expect(coords, [1, 2, 3, 4]);
+      });
+    });
+
+    group('coordsToLinear', () {
+      test('converts 3D coords to linear index', () {
+        // Strides [12, 4, 1] for shape [2, 3, 4]
+        final idx = TensorIndexer.coordsToLinear([1, 2, 3], [12, 4, 1]);
+
+        // Manual: 1*12 + 2*4 + 3*1 = 23
+        expect(idx, 23);
+      });
+
+      test('handles origin', () {
+        final idx = TensorIndexer.coordsToLinear([0, 0, 0], [12, 4, 1]);
+        expect(idx, 0);
+      });
+
+      test('handles non-contiguous strides', () {
+        // Transposed tensor: logical shape [4, 3], strides [1, 4]
+        // Coords [2, 1] → physical index 2*1 + 1*4 = 6
+        final idx = TensorIndexer.coordsToLinear([2, 1], [1, 4]);
+        expect(idx, 6);
+      });
+    });
+
+    group('computeStrides', () {
+      test('computes contiguous strides for 3D shape', () {
+        final strides = TensorIndexer.computeStrides([2, 3, 4]);
+        expect(strides, [12, 4, 1]);
+      });
+
+      test('computes contiguous strides for 4D shape', () {
+        final strides = TensorIndexer.computeStrides([2, 3, 4, 5]);
+        expect(strides, [60, 20, 5, 1]);
+      });
+
+      test('computes strides for 1D shape', () {
+        final strides = TensorIndexer.computeStrides([10]);
+        expect(strides, [1]);
+      });
+
+      test('computes strides for 2D shape', () {
+        final strides = TensorIndexer.computeStrides([3, 4]);
+        expect(strides, [4, 1]);
+      });
+
+      test('handles empty shape', () {
+        final strides = TensorIndexer.computeStrides([]);
+        expect(strides, []);
+      });
+    });
+
+    group('index4DNHWC', () {
+      test('computes correct index for NHWC tensor', () {
+        // Shape [2, 4, 5, 3] (N,H,W,C) → strides [60, 15, 3, 1]
+        // Element at [1, 2, 3, 2]
+        const H = 4, W = 5, C = 3;
+        final idx = TensorIndexer.index4DNHWC(1, 2, 3, 2, H, W, C);
+
+        // Manual: 1*60 + 2*15 + 3*3 + 2 = 60 + 30 + 9 + 2 = 101
+        expect(idx, 101);
+      });
+
+      test('produces different index than NCHW for same logical position', () {
+        // Same element position, different layout
+        // Choose values that definitely produce different indices
+        const b = 0, c = 1, h = 2, w = 3;
+        const C = 3, H = 4, W = 5;
+
+        final nchwIdx = TensorIndexer.index4D(b, c, h, w, C, H, W);
+        // NCHW: 0*60 + 1*20 + 2*5 + 3 = 33
+        final nhwcIdx = TensorIndexer.index4DNHWC(b, h, w, c, H, W, C);
+        // NHWC: 0*60 + 2*15 + 3*3 + 1 = 40
+
+        expect(nchwIdx, 33);
+        expect(nhwcIdx, 40);
+        expect(nchwIdx, isNot(equals(nhwcIdx)));
+      });
+    });
+
+    group('index3DHWC', () {
+      test('computes correct index for HWC tensor', () {
+        // Shape [4, 5, 3] (H,W,C) → strides [15, 3, 1]
+        const W = 5, C = 3;
+        final idx = TensorIndexer.index3DHWC(2, 3, 2, W, C);
+
+        // Manual: 2*15 + 3*3 + 2 = 30 + 9 + 2 = 41
+        expect(idx, 41);
+      });
+    });
+
+    group('round-trip consistency', () {
+      test('linearToCoords and coordsToLinear are inverse operations', () {
+        final shape = [2, 3, 4, 5];
+        final strides = TensorIndexer.computeStrides(shape);
+        final numel = shape.reduce((a, b) => a * b);
+
+        for (int i = 0; i < numel; i++) {
+          final coords = TensorIndexer.linearToCoords(i, shape);
+          final backToLinear = TensorIndexer.coordsToLinear(coords, strides);
+          expect(backToLinear, i);
+        }
+      });
+
+      test('index4D matches manual stride computation', () {
+        final shape = [2, 3, 4, 5];
+        final strides = TensorIndexer.computeStrides(shape);
+
+        for (int b = 0; b < shape[0]; b++) {
+          for (int c = 0; c < shape[1]; c++) {
+            for (int h = 0; h < shape[2]; h++) {
+              for (int w = 0; w < shape[3]; w++) {
+                final fromIndex4D =
+                    TensorIndexer.index4D(b, c, h, w, shape[1], shape[2], shape[3]);
+                final fromCoords =
+                    TensorIndexer.coordsToLinear([b, c, h, w], strides);
+                expect(fromIndex4D, fromCoords);
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+}

--- a/test/typed_data_views_test.dart
+++ b/test/typed_data_views_test.dart
@@ -1,0 +1,278 @@
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TypedDataViews', () {
+    group('float32SublistView', () {
+      test('creates zero-copy view', () {
+        final data = Float32List.fromList([1, 2, 3, 4, 5]);
+        final view = TypedDataViews.float32SublistView(data, 1, 4);
+
+        expect(view.length, equals(3));
+        expect(view[0], equals(2));
+        expect(view[1], equals(3));
+        expect(view[2], equals(4));
+
+        // Verify it's truly a view (modifications reflect in original)
+        view[0] = 99;
+        expect(data[1], equals(99));
+      });
+    });
+
+    group('float64SublistView', () {
+      test('creates zero-copy view', () {
+        final data = Float64List.fromList([1, 2, 3, 4, 5]);
+        final view = TypedDataViews.float64SublistView(data, 2);
+
+        expect(view.length, equals(3));
+        expect(view[0], equals(3));
+      });
+    });
+
+    group('viewAs', () {
+      test('creates float32 view from buffer', () {
+        final buffer = Float32List(10).buffer;
+        final view =
+            TypedDataViews.viewAs(buffer, DType.float32) as Float32List;
+
+        expect(view.length, equals(10));
+      });
+
+      test('creates view at offset', () {
+        final original = Float32List.fromList([1, 2, 3, 4, 5]);
+        final view = TypedDataViews.viewAs(
+          original.buffer,
+          DType.float32,
+          offsetInBytes: 4, // Skip first float32 (4 bytes)
+          length: 3,
+        ) as Float32List;
+
+        expect(view.length, equals(3));
+        expect(view[0], equals(2));
+      });
+    });
+  });
+
+  group('TensorViewExtension', () {
+    group('sliceFirst', () {
+      test('creates view of first dimension slice', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList(List.generate(24, (i) => i.toDouble())),
+          [4, 2, 3],
+        );
+
+        final slice = tensor.sliceFirst(1, 3);
+
+        expect(slice.shape, equals([2, 2, 3]));
+        // Check first element of slice (should be element 6 of original)
+        expect(slice[[0, 0, 0]], equals(6));
+      });
+
+      test('shares storage with original', () {
+        final data = Float32List.fromList(List.generate(12, (i) => i.toDouble()));
+        final tensor = TensorBuffer.fromFloat32List(data, [3, 4]);
+
+        final slice = tensor.sliceFirst(1, 2);
+
+        expect(identical(slice.storage, tensor.storage), isTrue);
+      });
+
+      test('throws for non-contiguous tensor', () {
+        final tensor = TensorBuffer.zeros([3, 4]).transpose([1, 0]);
+
+        expect(() => tensor.sliceFirst(0, 2), throwsStateError);
+      });
+
+      test('throws for invalid range', () {
+        final tensor = TensorBuffer.zeros([5, 3]);
+
+        expect(() => tensor.sliceFirst(-1, 3), throwsRangeError);
+        expect(() => tensor.sliceFirst(0, 6), throwsRangeError);
+        expect(() => tensor.sliceFirst(3, 2), throwsRangeError);
+      });
+    });
+
+    group('isViewable', () {
+      test('returns true for fresh tensor', () {
+        final tensor = TensorBuffer.zeros([3, 4]);
+
+        expect(tensor.isViewable, isTrue);
+      });
+
+      test('returns false for transposed tensor', () {
+        final tensor = TensorBuffer.zeros([3, 4]).transpose([1, 0]);
+
+        expect(tensor.isViewable, isFalse);
+      });
+
+      test('returns false for tensor with offset', () {
+        final tensor = TensorBuffer.zeros([5, 3]);
+        final slice = tensor.sliceFirst(1, 3);
+
+        expect(slice.isViewable, isFalse);
+      });
+    });
+
+    group('toChannelsLast', () {
+      test('converts NCHW to NHWC', () {
+        final nchw = TensorBuffer.zeros([2, 3, 4, 5]);
+
+        final nhwc = nchw.toChannelsLast();
+
+        expect(nhwc.shape, equals([2, 4, 5, 3]));
+        expect(identical(nhwc.storage, nchw.storage), isTrue);
+      });
+
+      test('throws for non-4D tensor', () {
+        final tensor = TensorBuffer.zeros([3, 4, 5]);
+
+        expect(() => tensor.toChannelsLast(), throwsStateError);
+      });
+    });
+
+    group('toChannelsFirst', () {
+      test('converts NHWC to NCHW', () {
+        final nhwc = TensorBuffer.zeros([2, 4, 5, 3]);
+
+        final nchw = nhwc.toChannelsFirst();
+
+        expect(nchw.shape, equals([2, 3, 4, 5]));
+      });
+    });
+
+    group('flatten', () {
+      test('creates 1D view', () {
+        final tensor = TensorBuffer.zeros([2, 3, 4]);
+
+        final flat = tensor.flatten();
+
+        expect(flat.shape, equals([24]));
+        expect(flat.numel, equals(24));
+      });
+
+      test('shares storage', () {
+        final tensor = TensorBuffer.zeros([2, 3]);
+
+        final flat = tensor.flatten();
+
+        expect(identical(flat.storage, tensor.storage), isTrue);
+      });
+
+      test('throws for non-contiguous tensor', () {
+        final tensor = TensorBuffer.zeros([3, 4]).transpose([1, 0]);
+
+        expect(() => tensor.flatten(), throwsStateError);
+      });
+    });
+
+    group('unbind', () {
+      test('splits tensor into views along dimension', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList(List.generate(12, (i) => i.toDouble())),
+          [3, 4],
+        );
+
+        final views = tensor.unbind(0);
+
+        expect(views.length, equals(3));
+        expect(views[0].shape, equals([4]));
+        expect(views[1].shape, equals([4]));
+        expect(views[2].shape, equals([4]));
+
+        // Check values
+        expect(views[0].toList(), equals([0, 1, 2, 3]));
+        expect(views[1].toList(), equals([4, 5, 6, 7]));
+        expect(views[2].toList(), equals([8, 9, 10, 11]));
+      });
+
+      test('all views share storage', () {
+        final tensor = TensorBuffer.zeros([5, 3, 4]);
+
+        final views = tensor.unbind(0);
+
+        for (final view in views) {
+          expect(identical(view.storage, tensor.storage), isTrue);
+        }
+      });
+
+      test('throws for invalid dim', () {
+        final tensor = TensorBuffer.zeros([3, 4]);
+
+        expect(() => tensor.unbind(-1), throwsRangeError);
+        expect(() => tensor.unbind(2), throwsRangeError);
+      });
+    });
+
+    group('select', () {
+      test('selects single index reducing rank', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList(List.generate(24, (i) => i.toDouble())),
+          [2, 3, 4],
+        );
+
+        final selected = tensor.select(0, 1);
+
+        expect(selected.shape, equals([3, 4]));
+        expect(selected[[0, 0]], equals(12)); // First element of second batch
+      });
+
+      test('shares storage', () {
+        final tensor = TensorBuffer.zeros([5, 3, 4]);
+
+        final selected = tensor.select(1, 2);
+
+        expect(identical(selected.storage, tensor.storage), isTrue);
+      });
+
+      test('throws for invalid dim', () {
+        final tensor = TensorBuffer.zeros([3, 4]);
+
+        expect(() => tensor.select(2, 0), throwsRangeError);
+      });
+
+      test('throws for invalid index', () {
+        final tensor = TensorBuffer.zeros([3, 4]);
+
+        expect(() => tensor.select(0, 5), throwsRangeError);
+      });
+    });
+
+    group('narrow', () {
+      test('narrows dimension', () {
+        final tensor = TensorBuffer.fromFloat32List(
+          Float32List.fromList(List.generate(20, (i) => i.toDouble())),
+          [5, 4],
+        );
+
+        final narrowed = tensor.narrow(0, 1, 3);
+
+        expect(narrowed.shape, equals([3, 4]));
+        expect(narrowed[[0, 0]], equals(4)); // Row 1 of original
+        expect(narrowed[[2, 3]], equals(15)); // Row 3, col 3 of original
+      });
+
+      test('shares storage', () {
+        final tensor = TensorBuffer.zeros([5, 3, 4]);
+
+        final narrowed = tensor.narrow(0, 1, 2);
+
+        expect(identical(narrowed.storage, tensor.storage), isTrue);
+      });
+
+      test('throws for invalid range', () {
+        final tensor = TensorBuffer.zeros([5, 4]);
+
+        expect(() => tensor.narrow(0, -1, 2), throwsRangeError);
+        expect(() => tensor.narrow(0, 4, 2), throwsRangeError);
+      });
+
+      test('throws for invalid dim', () {
+        final tensor = TensorBuffer.zeros([3, 4]);
+
+        expect(() => tensor.narrow(2, 0, 1), throwsRangeError);
+      });
+    });
+  });
+}


### PR DESCRIPTION
- **BufferPool** - Memory pooling API for buffer reuse (`buffer_pool.dart`):
  - Singleton `BufferPool.instance` for global buffer reuse
  - Power-of-2 size bucketing for efficient allocation
  - Per-dtype buffer pools (Float32, Float64, Int32, Uint8, etc.)
  - `acquire(minSize, dtype)` and `release(buffer)` methods
  - `acquireFloat32()`, `acquireFloat64()`, etc. convenience extensions
  - Max buffers per bucket limit (8) to prevent unbounded memory growth
  - `pooledCount` and `pooledBytes` for monitoring
- **TypedData Views** - Zero-copy tensor view utilities (`typed_data_views.dart`):
  - `TypedDataViews.float32SublistView()` - Zero-copy Float32List slicing
  - `TypedDataViews.float64SublistView()` - Zero-copy Float64List slicing
  - `TypedDataViews.viewAs()` - Create typed view from ByteBuffer at offset
  - `TensorViewExtension` on TensorBuffer:
    - `sliceFirst(start, end)` - Zero-copy slice along first dimension
    - `isViewable` - Check if tensor can be used as a view
    - `toChannelsLast()` - NCHW to NHWC without copying
    - `toChannelsFirst()` - NHWC to NCHW without copying
    - `flatten()` - 1D view of contiguous tensor
    - `unbind(dim)` - Split tensor into views along dimension
    - `select(dim, index)` - Select single index with reduced rank
    - `narrow(dim, start, length)` - Narrow dimension without copying
- **Utility Libraries** (`lib/src/utils/`):
  - `dtype_dispatcher.dart` - DTypeDispatcher for dtype-specialized dispatch
  - `tensor_indexing.dart` - TensorIndexer for index calculations (index2D, index3D, index4D, linearToCoords, coordsToLinear, computeStrides)
- **TensorBuffer/TensorStorage Factory Methods**:
  - `TensorBuffer.fromFloat64List()` - Create tensor from Float64List
  - `TensorStorage.fromFloat64List()` - Create storage from Float64List