### PR TITLE
refactor: structural improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-01-20
+
+### Internal
+
+- **TensorBuffer Factory Separation** - Moved factory methods to separate file:
+  - `tensor_buffer_factory.dart` contains: zeros, ones, full, random, randn, eye, linspace, arange, fromFloat32List, fromFloat64List, fromUint8List
+  - Reduces `tensor_buffer.dart` from ~840 lines to ~530 lines
+  - No API changes
+
+- **OpValidator** - Added centralized operation validation (`validation_utils.dart`):
+  - `OpValidator.validateRank()` - Validates tensor rank range
+  - `OpValidator.validateAxis()` - Validates and normalizes axis (supports negative indexing)
+  - `OpValidator.validateChannels()` - Validates channel count
+  - `OpValidator.validatePositiveDimension()` - Validates positive dimension
+  - `OpValidator.validateListLength()` - Validates list length
+
+- **OperationCapabilities** - Added operation metadata (`transform_op.dart`):
+  - `supportsInPlace` - Whether op can modify tensor in place
+  - `requiresContiguous` - Whether op requires contiguous memory
+  - `preservesShape` - Whether op preserves input shape
+  - `modifiesDType` - Whether op may change data type
+  - Default `capabilities` getter on `TransformOp`
+
 ## [0.6.1] - 2026-01-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tensor preprocessing library for Flutter/Dart. NumPy-like transforms pipeline fo
 
 ```yaml
 dependencies:
-  dart_tensor_preprocessing: ^0.6.1
+  dart_tensor_preprocessing: ^0.6.2
 ```
 
 ## Quick Start

--- a/lib/src/core/tensor_buffer.dart
+++ b/lib/src/core/tensor_buffer.dart
@@ -5,6 +5,8 @@ import 'dtype.dart';
 import 'memory_format.dart';
 import 'tensor_storage.dart';
 
+part 'tensor_buffer_factory.dart';
+
 /// A multi-dimensional array view over typed data with shape and stride metadata.
 ///
 /// [TensorBuffer] provides a NumPy-like interface for tensor operations. It
@@ -347,56 +349,15 @@ class TensorBuffer {
     List<int> shape, {
     DType dtype = DType.float32,
     MemoryFormat memoryFormat = MemoryFormat.contiguous,
-  }) {
-    _validateShapeStatic(shape);
-    final numel = shape.fold(1, (a, b) => a * b);
-    final data = dtype.createBuffer(numel);
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable(shape),
-      memoryFormat: memoryFormat,
-    );
-  }
+  }) =>
+      _zerosImpl(shape, dtype: dtype, memoryFormat: memoryFormat);
 
   /// Creates a tensor filled with ones.
   static TensorBuffer ones(
     List<int> shape, {
     DType dtype = DType.float32,
-  }) {
-    _validateShapeStatic(shape);
-    final numel = shape.fold(1, (a, b) => a * b);
-    final data = dtype.createBuffer(numel);
-
-    for (int i = 0; i < numel; i++) {
-      switch (data) {
-        case final Float32List list:
-          list[i] = 1.0;
-        case final Float64List list:
-          list[i] = 1.0;
-        case final Int8List list:
-          list[i] = 1;
-        case final Int16List list:
-          list[i] = 1;
-        case final Int32List list:
-          list[i] = 1;
-        case final Int64List list:
-          list[i] = 1;
-        case final Uint8List list:
-          list[i] = 1;
-        case final Uint16List list:
-          list[i] = 1;
-        case final Uint32List list:
-          list[i] = 1;
-        case final Uint64List list:
-          list[i] = 1;
-      }
-    }
-
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable(shape),
-    );
-  }
+  }) =>
+      _onesImpl(shape, dtype: dtype);
 
   /// Creates a tensor filled with a specific value.
   ///
@@ -409,41 +370,8 @@ class TensorBuffer {
     List<int> shape, {
     required double fillValue,
     DType dtype = DType.float32,
-  }) {
-    _validateShapeStatic(shape);
-    final numel = shape.fold(1, (a, b) => a * b);
-    final data = dtype.createBuffer(numel);
-
-    for (int i = 0; i < numel; i++) {
-      switch (data) {
-        case final Float32List list:
-          list[i] = fillValue;
-        case final Float64List list:
-          list[i] = fillValue;
-        case final Int8List list:
-          list[i] = fillValue.toInt();
-        case final Int16List list:
-          list[i] = fillValue.toInt();
-        case final Int32List list:
-          list[i] = fillValue.toInt();
-        case final Int64List list:
-          list[i] = fillValue.toInt();
-        case final Uint8List list:
-          list[i] = fillValue.toInt().clamp(0, 255);
-        case final Uint16List list:
-          list[i] = fillValue.toInt().clamp(0, 65535);
-        case final Uint32List list:
-          list[i] = fillValue.toInt();
-        case final Uint64List list:
-          list[i] = fillValue.toInt();
-      }
-    }
-
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable(shape),
-    );
-  }
+  }) =>
+      _fullImpl(shape, fillValue: fillValue, dtype: dtype);
 
   /// Creates a tensor with random values uniformly distributed in [0, 1).
   ///
@@ -457,21 +385,8 @@ class TensorBuffer {
     List<int> shape, {
     DType dtype = DType.float32,
     int? seed,
-  }) {
-    _validateShapeStatic(shape);
-    final numel = shape.fold(1, (a, b) => a * b);
-    final data = Float32List(numel);
-    final rng = seed != null ? _SeededRandom(seed) : _SeededRandom.system();
-
-    for (int i = 0; i < numel; i++) {
-      data[i] = rng.nextDouble();
-    }
-
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable(shape),
-    );
-  }
+  }) =>
+      _randomImpl(shape, dtype: dtype, seed: seed);
 
   /// Creates a tensor with random values from a standard normal distribution N(0, 1).
   ///
@@ -485,31 +400,8 @@ class TensorBuffer {
     List<int> shape, {
     DType dtype = DType.float32,
     int? seed,
-  }) {
-    _validateShapeStatic(shape);
-    final numel = shape.fold(1, (a, b) => a * b);
-    final data = Float32List(numel);
-    final rng = seed != null ? _SeededRandom(seed) : _SeededRandom.system();
-
-    // Box-Muller transform for normal distribution
-    for (int i = 0; i < numel; i += 2) {
-      final u1 = rng.nextDouble();
-      final u2 = rng.nextDouble();
-      // Avoid log(0)
-      final safeU1 = u1 < 1e-10 ? 1e-10 : u1;
-      final r = _sqrt(-2.0 * _log(safeU1));
-      final theta = 2.0 * _pi * u2;
-      data[i] = r * _cos(theta);
-      if (i + 1 < numel) {
-        data[i + 1] = r * _sin(theta);
-      }
-    }
-
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable(shape),
-    );
-  }
+  }) =>
+      _randnImpl(shape, dtype: dtype, seed: seed);
 
   /// Creates a 2D identity matrix.
   ///
@@ -523,26 +415,8 @@ class TensorBuffer {
     int n, {
     int? m,
     DType dtype = DType.float32,
-  }) {
-    if (n <= 0) {
-      throw InvalidParameterException('n', n, 'n must be positive');
-    }
-    final cols = m ?? n;
-    if (cols <= 0) {
-      throw InvalidParameterException('m', cols, 'm must be positive');
-    }
-
-    final data = Float32List(n * cols);
-    final diagSize = n < cols ? n : cols;
-    for (int i = 0; i < diagSize; i++) {
-      data[i * cols + i] = 1.0;
-    }
-
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable([n, cols]),
-    );
-  }
+  }) =>
+      _eyeImpl(n, m: m, dtype: dtype);
 
   /// Creates a 1D tensor with evenly spaced values.
   ///
@@ -557,27 +431,8 @@ class TensorBuffer {
     double end, {
     required int steps,
     DType dtype = DType.float32,
-  }) {
-    if (steps < 1) {
-      throw InvalidParameterException('steps', steps, 'steps must be >= 1');
-    }
-
-    final data = Float32List(steps);
-
-    if (steps == 1) {
-      data[0] = start;
-    } else {
-      final step = (end - start) / (steps - 1);
-      for (int i = 0; i < steps; i++) {
-        data[i] = start + i * step;
-      }
-    }
-
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable([steps]),
-    );
-  }
+  }) =>
+      _linspaceImpl(start, end, steps: steps, dtype: dtype);
 
   /// Creates a 1D tensor with values in a range with a given step.
   ///
@@ -595,87 +450,26 @@ class TensorBuffer {
     required double end,
     double step = 1.0,
     DType dtype = DType.float32,
-  }) {
-    if (step == 0) {
-      throw InvalidParameterException('step', step, 'step cannot be zero');
-    }
-    if ((end > start && step < 0) || (end < start && step > 0)) {
-      throw InvalidParameterException(
-        'step',
-        step,
-        'step direction does not match range direction',
-      );
-    }
-
-    final numSteps = ((end - start) / step).ceil();
-    if (numSteps <= 0) {
-      return TensorBuffer(
-        storage: TensorStorage(Float32List(0), dtype),
-        shape: List.unmodifiable([0]),
-      );
-    }
-
-    final data = Float32List(numSteps);
-    for (int i = 0; i < numSteps; i++) {
-      data[i] = start + i * step;
-    }
-
-    return TensorBuffer(
-      storage: TensorStorage(data, dtype),
-      shape: List.unmodifiable([numSteps]),
-    );
-  }
+  }) =>
+      _arangeImpl(start: start, end: end, step: step, dtype: dtype);
 
   /// Creates a tensor from an existing [Float32List] with the given [shape].
   ///
   /// Throws [ShapeMismatchException] if data length doesn't match shape.
-  static TensorBuffer fromFloat32List(Float32List data, List<int> shape) {
-    final expectedNumel = shape.fold(1, (a, b) => a * b);
-    if (data.length != expectedNumel) {
-      throw ShapeMismatchException(
-        actual: shape,
-        message: 'Data length (${data.length}) does not match shape $shape (numel: $expectedNumel)',
-      );
-    }
-    return TensorBuffer(
-      storage: TensorStorage.fromFloat32List(data),
-      shape: List.unmodifiable(shape),
-    );
-  }
+  static TensorBuffer fromFloat32List(Float32List data, List<int> shape) =>
+      _fromFloat32ListImpl(data, shape);
 
   /// Creates a tensor from an existing [Float64List] with the given [shape].
   ///
   /// Throws [ShapeMismatchException] if data length doesn't match shape.
-  static TensorBuffer fromFloat64List(Float64List data, List<int> shape) {
-    final expectedNumel = shape.fold(1, (a, b) => a * b);
-    if (data.length != expectedNumel) {
-      throw ShapeMismatchException(
-        actual: shape,
-        message: 'Data length (${data.length}) does not match shape $shape (numel: $expectedNumel)',
-      );
-    }
-    return TensorBuffer(
-      storage: TensorStorage.fromFloat64List(data),
-      shape: List.unmodifiable(shape),
-    );
-  }
+  static TensorBuffer fromFloat64List(Float64List data, List<int> shape) =>
+      _fromFloat64ListImpl(data, shape);
 
   /// Creates a tensor from an existing [Uint8List] with the given [shape].
   ///
   /// Throws [ShapeMismatchException] if data length doesn't match shape.
-  static TensorBuffer fromUint8List(Uint8List data, List<int> shape) {
-    final expectedNumel = shape.fold(1, (a, b) => a * b);
-    if (data.length != expectedNumel) {
-      throw ShapeMismatchException(
-        actual: shape,
-        message: 'Data length (${data.length}) does not match shape $shape (numel: $expectedNumel)',
-      );
-    }
-    return TensorBuffer(
-      storage: TensorStorage.fromUint8List(data),
-      shape: List.unmodifiable(shape),
-    );
-  }
+  static TensorBuffer fromUint8List(Uint8List data, List<int> shape) =>
+      _fromUint8ListImpl(data, shape);
 
   /// Computes strides for a tensor with the given [shape] and [format].
   static List<int> computeStrides(List<int> shape, MemoryFormat format) {
@@ -734,103 +528,5 @@ class TensorBuffer {
   String toString() {
     return 'TensorBuffer(shape: $shape, dtype: $dtype, '
         'strides: $strides, contiguous: $isContiguous)';
-  }
-}
-
-// Math function aliases for random number generation
-double _sqrt(double x) => x >= 0 ? _power(x, 0.5) : double.nan;
-double _log(double x) {
-  if (x <= 0) return double.negativeInfinity;
-  // Natural log approximation using Taylor series or built-in
-  double result = 0;
-  double term = (x - 1) / (x + 1);
-  final termSq = term * term;
-  for (int i = 1; i <= 100; i += 2) {
-    result += term / i;
-    term *= termSq;
-  }
-  return 2 * result;
-}
-
-double _power(double base, double exp) {
-  if (exp == 0.5) {
-    // Newton's method for square root
-    if (base < 0) return double.nan;
-    if (base == 0) return 0;
-    double guess = base / 2;
-    for (int i = 0; i < 20; i++) {
-      guess = (guess + base / guess) / 2;
-    }
-    return guess;
-  }
-  // For other cases, use exp(exp * ln(base))
-  return _exp(exp * _log(base));
-}
-
-double _exp(double x) {
-  double result = 1;
-  double term = 1;
-  for (int i = 1; i <= 30; i++) {
-    term *= x / i;
-    result += term;
-    if (term.abs() < 1e-15) break;
-  }
-  return result;
-}
-
-const double _pi = 3.14159265358979323846;
-
-double _cos(double x) {
-  // Normalize to [-pi, pi]
-  while (x > _pi) {
-    x -= 2 * _pi;
-  }
-  while (x < -_pi) {
-    x += 2 * _pi;
-  }
-
-  double result = 1;
-  double term = 1;
-  final xSq = x * x;
-  for (int i = 1; i <= 15; i++) {
-    term *= -xSq / ((2 * i - 1) * (2 * i));
-    result += term;
-  }
-  return result;
-}
-
-double _sin(double x) {
-  // Normalize to [-pi, pi]
-  while (x > _pi) {
-    x -= 2 * _pi;
-  }
-  while (x < -_pi) {
-    x += 2 * _pi;
-  }
-
-  double result = x;
-  double term = x;
-  final xSq = x * x;
-  for (int i = 1; i <= 15; i++) {
-    term *= -xSq / ((2 * i) * (2 * i + 1));
-    result += term;
-  }
-  return result;
-}
-
-/// Simple seeded random number generator (Linear Congruential Generator).
-class _SeededRandom {
-  int _state;
-
-  _SeededRandom(int seed) : _state = seed & 0xFFFFFFFF;
-
-  factory _SeededRandom.system() {
-    return _SeededRandom(DateTime.now().microsecondsSinceEpoch);
-  }
-
-  double nextDouble() {
-    // LCG parameters (same as glibc)
-    _state = ((_state * 1103515245) + 12345) & 0x7FFFFFFF;
-    return _state / 0x7FFFFFFF;
   }
 }

--- a/lib/src/core/tensor_buffer_factory.dart
+++ b/lib/src/core/tensor_buffer_factory.dart
@@ -1,0 +1,470 @@
+part of 'tensor_buffer.dart';
+
+// ============================================================================
+// TensorBuffer Factory Methods
+// ============================================================================
+
+/// Extension on TensorBuffer for factory methods.
+///
+/// This file contains all static factory constructors for TensorBuffer:
+/// - zeros, ones, full
+/// - random, randn
+/// - eye, linspace, arange
+/// - fromFloat32List, fromFloat64List, fromUint8List
+
+extension TensorBufferFactory on TensorBuffer {
+  // This extension is a placeholder for documentation purposes.
+  // The actual factory methods are static methods on TensorBuffer,
+  // which work through the `part of` directive.
+}
+
+// ============================================================================
+// Factory Methods (as static extensions via part)
+// ============================================================================
+
+// Note: The following are implemented as static methods on TensorBuffer
+// in the main tensor_buffer.dart file, but their implementations are here.
+
+/// Creates a tensor filled with zeros.
+TensorBuffer _zerosImpl(
+  List<int> shape, {
+  DType dtype = DType.float32,
+  MemoryFormat memoryFormat = MemoryFormat.contiguous,
+}) {
+  TensorBuffer._validateShapeStatic(shape);
+  final numel = shape.fold(1, (a, b) => a * b);
+  final data = dtype.createBuffer(numel);
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable(shape),
+    memoryFormat: memoryFormat,
+  );
+}
+
+/// Creates a tensor filled with ones.
+TensorBuffer _onesImpl(
+  List<int> shape, {
+  DType dtype = DType.float32,
+}) {
+  TensorBuffer._validateShapeStatic(shape);
+  final numel = shape.fold(1, (a, b) => a * b);
+  final data = dtype.createBuffer(numel);
+
+  for (int i = 0; i < numel; i++) {
+    switch (data) {
+      case final Float32List list:
+        list[i] = 1.0;
+      case final Float64List list:
+        list[i] = 1.0;
+      case final Int8List list:
+        list[i] = 1;
+      case final Int16List list:
+        list[i] = 1;
+      case final Int32List list:
+        list[i] = 1;
+      case final Int64List list:
+        list[i] = 1;
+      case final Uint8List list:
+        list[i] = 1;
+      case final Uint16List list:
+        list[i] = 1;
+      case final Uint32List list:
+        list[i] = 1;
+      case final Uint64List list:
+        list[i] = 1;
+    }
+  }
+
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable(shape),
+  );
+}
+
+/// Creates a tensor filled with a specific value.
+///
+/// Equivalent to `torch.full()` in PyTorch.
+///
+/// ```dart
+/// final tensor = TensorBuffer.full([3, 3], fillValue: 5.0);
+/// ```
+TensorBuffer _fullImpl(
+  List<int> shape, {
+  required double fillValue,
+  DType dtype = DType.float32,
+}) {
+  TensorBuffer._validateShapeStatic(shape);
+  final numel = shape.fold(1, (a, b) => a * b);
+  final data = dtype.createBuffer(numel);
+
+  for (int i = 0; i < numel; i++) {
+    switch (data) {
+      case final Float32List list:
+        list[i] = fillValue;
+      case final Float64List list:
+        list[i] = fillValue;
+      case final Int8List list:
+        list[i] = fillValue.toInt();
+      case final Int16List list:
+        list[i] = fillValue.toInt();
+      case final Int32List list:
+        list[i] = fillValue.toInt();
+      case final Int64List list:
+        list[i] = fillValue.toInt();
+      case final Uint8List list:
+        list[i] = fillValue.toInt().clamp(0, 255);
+      case final Uint16List list:
+        list[i] = fillValue.toInt().clamp(0, 65535);
+      case final Uint32List list:
+        list[i] = fillValue.toInt();
+      case final Uint64List list:
+        list[i] = fillValue.toInt();
+    }
+  }
+
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable(shape),
+  );
+}
+
+/// Creates a tensor with random values uniformly distributed in [0, 1).
+///
+/// Equivalent to `torch.rand()` in PyTorch.
+///
+/// ```dart
+/// final tensor = TensorBuffer.random([3, 224, 224]);
+/// final seeded = TensorBuffer.random([3, 224, 224], seed: 42);
+/// ```
+TensorBuffer _randomImpl(
+  List<int> shape, {
+  DType dtype = DType.float32,
+  int? seed,
+}) {
+  TensorBuffer._validateShapeStatic(shape);
+  final numel = shape.fold(1, (a, b) => a * b);
+  final data = Float32List(numel);
+  final rng = seed != null ? _SeededRandom(seed) : _SeededRandom.system();
+
+  for (int i = 0; i < numel; i++) {
+    data[i] = rng.nextDouble();
+  }
+
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable(shape),
+  );
+}
+
+/// Creates a tensor with random values from a standard normal distribution N(0, 1).
+///
+/// Equivalent to `torch.randn()` in PyTorch.
+///
+/// ```dart
+/// final tensor = TensorBuffer.randn([3, 224, 224]);
+/// final seeded = TensorBuffer.randn([3, 224, 224], seed: 42);
+/// ```
+TensorBuffer _randnImpl(
+  List<int> shape, {
+  DType dtype = DType.float32,
+  int? seed,
+}) {
+  TensorBuffer._validateShapeStatic(shape);
+  final numel = shape.fold(1, (a, b) => a * b);
+  final data = Float32List(numel);
+  final rng = seed != null ? _SeededRandom(seed) : _SeededRandom.system();
+
+  // Box-Muller transform for normal distribution
+  for (int i = 0; i < numel; i += 2) {
+    final u1 = rng.nextDouble();
+    final u2 = rng.nextDouble();
+    // Avoid log(0)
+    final safeU1 = u1 < 1e-10 ? 1e-10 : u1;
+    final r = _sqrt(-2.0 * _log(safeU1));
+    final theta = 2.0 * _pi * u2;
+    data[i] = r * _cos(theta);
+    if (i + 1 < numel) {
+      data[i + 1] = r * _sin(theta);
+    }
+  }
+
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable(shape),
+  );
+}
+
+/// Creates a 2D identity matrix.
+///
+/// Equivalent to `torch.eye()` in PyTorch.
+///
+/// ```dart
+/// final tensor = TensorBuffer.eye(3); // 3x3 identity matrix
+/// final rect = TensorBuffer.eye(2, m: 4); // 2x4 matrix with 1s on diagonal
+/// ```
+TensorBuffer _eyeImpl(
+  int n, {
+  int? m,
+  DType dtype = DType.float32,
+}) {
+  if (n <= 0) {
+    throw InvalidParameterException('n', n, 'n must be positive');
+  }
+  final cols = m ?? n;
+  if (cols <= 0) {
+    throw InvalidParameterException('m', cols, 'm must be positive');
+  }
+
+  final data = Float32List(n * cols);
+  final diagSize = n < cols ? n : cols;
+  for (int i = 0; i < diagSize; i++) {
+    data[i * cols + i] = 1.0;
+  }
+
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable([n, cols]),
+  );
+}
+
+/// Creates a 1D tensor with evenly spaced values.
+///
+/// Equivalent to `torch.linspace()` in PyTorch.
+///
+/// ```dart
+/// final tensor = TensorBuffer.linspace(0.0, 1.0, steps: 5);
+/// // [0.0, 0.25, 0.5, 0.75, 1.0]
+/// ```
+TensorBuffer _linspaceImpl(
+  double start,
+  double end, {
+  required int steps,
+  DType dtype = DType.float32,
+}) {
+  if (steps < 1) {
+    throw InvalidParameterException('steps', steps, 'steps must be >= 1');
+  }
+
+  final data = Float32List(steps);
+
+  if (steps == 1) {
+    data[0] = start;
+  } else {
+    final step = (end - start) / (steps - 1);
+    for (int i = 0; i < steps; i++) {
+      data[i] = start + i * step;
+    }
+  }
+
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable([steps]),
+  );
+}
+
+/// Creates a 1D tensor with values in a range with a given step.
+///
+/// Equivalent to `torch.arange()` in PyTorch.
+///
+/// ```dart
+/// final tensor = TensorBuffer.arange(start: 0.0, end: 5.0);
+/// // [0.0, 1.0, 2.0, 3.0, 4.0]
+///
+/// final stepped = TensorBuffer.arange(start: 0.0, end: 10.0, step: 2.0);
+/// // [0.0, 2.0, 4.0, 6.0, 8.0]
+/// ```
+TensorBuffer _arangeImpl({
+  required double start,
+  required double end,
+  double step = 1.0,
+  DType dtype = DType.float32,
+}) {
+  if (step == 0) {
+    throw InvalidParameterException('step', step, 'step cannot be zero');
+  }
+  if ((end > start && step < 0) || (end < start && step > 0)) {
+    throw InvalidParameterException(
+      'step',
+      step,
+      'step direction does not match range direction',
+    );
+  }
+
+  final numSteps = ((end - start) / step).ceil();
+  if (numSteps <= 0) {
+    return TensorBuffer(
+      storage: TensorStorage(Float32List(0), dtype),
+      shape: List.unmodifiable([0]),
+    );
+  }
+
+  final data = Float32List(numSteps);
+  for (int i = 0; i < numSteps; i++) {
+    data[i] = start + i * step;
+  }
+
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable([numSteps]),
+  );
+}
+
+/// Creates a tensor from an existing [Float32List] with the given [shape].
+///
+/// Throws [ShapeMismatchException] if data length doesn't match shape.
+TensorBuffer _fromFloat32ListImpl(Float32List data, List<int> shape) {
+  final expectedNumel = shape.fold(1, (a, b) => a * b);
+  if (data.length != expectedNumel) {
+    throw ShapeMismatchException(
+      actual: shape,
+      message:
+          'Data length (${data.length}) does not match shape $shape (numel: $expectedNumel)',
+    );
+  }
+  return TensorBuffer(
+    storage: TensorStorage.fromFloat32List(data),
+    shape: List.unmodifiable(shape),
+  );
+}
+
+/// Creates a tensor from an existing [Float64List] with the given [shape].
+///
+/// Throws [ShapeMismatchException] if data length doesn't match shape.
+TensorBuffer _fromFloat64ListImpl(Float64List data, List<int> shape) {
+  final expectedNumel = shape.fold(1, (a, b) => a * b);
+  if (data.length != expectedNumel) {
+    throw ShapeMismatchException(
+      actual: shape,
+      message:
+          'Data length (${data.length}) does not match shape $shape (numel: $expectedNumel)',
+    );
+  }
+  return TensorBuffer(
+    storage: TensorStorage.fromFloat64List(data),
+    shape: List.unmodifiable(shape),
+  );
+}
+
+/// Creates a tensor from an existing [Uint8List] with the given [shape].
+///
+/// Throws [ShapeMismatchException] if data length doesn't match shape.
+TensorBuffer _fromUint8ListImpl(Uint8List data, List<int> shape) {
+  final expectedNumel = shape.fold(1, (a, b) => a * b);
+  if (data.length != expectedNumel) {
+    throw ShapeMismatchException(
+      actual: shape,
+      message:
+          'Data length (${data.length}) does not match shape $shape (numel: $expectedNumel)',
+    );
+  }
+  return TensorBuffer(
+    storage: TensorStorage.fromUint8List(data),
+    shape: List.unmodifiable(shape),
+  );
+}
+
+// ============================================================================
+// Math Helpers for Random Number Generation
+// ============================================================================
+
+double _sqrt(double x) => x >= 0 ? _power(x, 0.5) : double.nan;
+
+double _log(double x) {
+  if (x <= 0) return double.negativeInfinity;
+  // Natural log approximation using Taylor series or built-in
+  double result = 0;
+  double term = (x - 1) / (x + 1);
+  final termSq = term * term;
+  for (int i = 1; i <= 100; i += 2) {
+    result += term / i;
+    term *= termSq;
+  }
+  return 2 * result;
+}
+
+double _power(double base, double exp) {
+  if (exp == 0.5) {
+    // Newton's method for square root
+    if (base < 0) return double.nan;
+    if (base == 0) return 0;
+    double guess = base / 2;
+    for (int i = 0; i < 20; i++) {
+      guess = (guess + base / guess) / 2;
+    }
+    return guess;
+  }
+  // For other cases, use exp(exp * ln(base))
+  return _exp(exp * _log(base));
+}
+
+double _exp(double x) {
+  double result = 1;
+  double term = 1;
+  for (int i = 1; i <= 30; i++) {
+    term *= x / i;
+    result += term;
+    if (term.abs() < 1e-15) break;
+  }
+  return result;
+}
+
+const double _pi = 3.14159265358979323846;
+
+double _cos(double x) {
+  // Normalize to [-pi, pi]
+  while (x > _pi) {
+    x -= 2 * _pi;
+  }
+  while (x < -_pi) {
+    x += 2 * _pi;
+  }
+
+  double result = 1;
+  double term = 1;
+  final xSq = x * x;
+  for (int i = 1; i <= 15; i++) {
+    term *= -xSq / ((2 * i - 1) * (2 * i));
+    result += term;
+  }
+  return result;
+}
+
+double _sin(double x) {
+  // Normalize to [-pi, pi]
+  while (x > _pi) {
+    x -= 2 * _pi;
+  }
+  while (x < -_pi) {
+    x += 2 * _pi;
+  }
+
+  double result = x;
+  double term = x;
+  final xSq = x * x;
+  for (int i = 1; i <= 15; i++) {
+    term *= -xSq / ((2 * i) * (2 * i + 1));
+    result += term;
+  }
+  return result;
+}
+
+// ============================================================================
+// Seeded Random Number Generator
+// ============================================================================
+
+/// Simple seeded random number generator (Linear Congruential Generator).
+class _SeededRandom {
+  int _state;
+
+  _SeededRandom(int seed) : _state = seed & 0xFFFFFFFF;
+
+  factory _SeededRandom.system() {
+    return _SeededRandom(DateTime.now().microsecondsSinceEpoch);
+  }
+
+  double nextDouble() {
+    // LCG parameters (same as glibc)
+    _state = ((_state * 1103515245) + 12345) & 0x7FFFFFFF;
+    return _state / 0x7FFFFFFF;
+  }
+}

--- a/lib/src/ops/transform_op.dart
+++ b/lib/src/ops/transform_op.dart
@@ -1,5 +1,73 @@
 import '../core/tensor_buffer.dart';
 
+// ============================================================================
+// Operation Capabilities
+// ============================================================================
+
+/// Describes the capabilities and characteristics of a tensor operation.
+///
+/// This metadata helps pipeline optimizers understand operation behavior
+/// without executing them. Use this for:
+/// - In-place operation chaining
+/// - Memory allocation planning
+/// - Pipeline fusion opportunities
+///
+/// Example:
+/// ```dart
+/// class MyOp extends TransformOp {
+///   @override
+///   OperationCapabilities get capabilities => const OperationCapabilities(
+///     supportsInPlace: true,
+///     preservesShape: true,
+///   );
+/// }
+/// ```
+class OperationCapabilities {
+  /// Whether the operation can modify the input tensor in place.
+  ///
+  /// Operations with `supportsInPlace: true` typically also implement
+  /// the [InPlaceTransform] mixin.
+  final bool supportsInPlace;
+
+  /// Whether the operation requires contiguous memory layout.
+  ///
+  /// Operations with `requiresContiguous: true` typically also implement
+  /// the [RequiresContiguous] mixin.
+  final bool requiresContiguous;
+
+  /// Whether the operation preserves the input shape.
+  ///
+  /// `true` for element-wise operations (normalize, relu, etc.)
+  /// `false` for shape-changing operations (resize, reshape, etc.)
+  final bool preservesShape;
+
+  /// Whether the operation may change the data type.
+  ///
+  /// `true` for type casting operations
+  /// `false` for most operations that preserve dtype
+  final bool modifiesDType;
+
+  /// Creates operation capabilities with the specified characteristics.
+  const OperationCapabilities({
+    this.supportsInPlace = false,
+    this.requiresContiguous = false,
+    this.preservesShape = true,
+    this.modifiesDType = false,
+  });
+
+  /// Default capabilities for operations that don't specify their own.
+  static const defaultCapabilities = OperationCapabilities();
+
+  @override
+  String toString() =>
+      'OperationCapabilities(inPlace: $supportsInPlace, contiguous: $requiresContiguous, '
+      'preservesShape: $preservesShape, modifiesDType: $modifiesDType)';
+}
+
+// ============================================================================
+// Transform Operation Base Class
+// ============================================================================
+
 /// Base class for all tensor transform operations.
 ///
 /// Subclasses implement [apply] to perform the actual transformation and
@@ -8,6 +76,13 @@ import '../core/tensor_buffer.dart';
 abstract class TransformOp {
   /// The human-readable name of this operation.
   String get name;
+
+  /// The capabilities of this operation.
+  ///
+  /// Override this getter to specify operation-specific capabilities.
+  /// Default returns [OperationCapabilities.defaultCapabilities].
+  OperationCapabilities get capabilities =>
+      OperationCapabilities.defaultCapabilities;
 
   /// Applies this transform to [input] and returns the result.
   TensorBuffer apply(TensorBuffer input);

--- a/lib/src/utils/validation_utils.dart
+++ b/lib/src/utils/validation_utils.dart
@@ -74,3 +74,143 @@ void requireNonNegative(num value, String paramName) {
     );
   }
 }
+
+// ============================================================================
+// OpValidator - Centralized operation validation
+// ============================================================================
+
+/// Centralized validation utilities for tensor operations.
+///
+/// Provides static methods for common validation patterns with consistent
+/// error messages that include the operation name for better debugging.
+///
+/// Example:
+/// ```dart
+/// class MyOp extends TransformOp {
+///   @override
+///   TensorBuffer apply(TensorBuffer input) {
+///     OpValidator.validateRank(
+///       input.shape,
+///       minRank: 3,
+///       maxRank: 4,
+///       operationName: name,
+///     );
+///     // ...
+///   }
+/// }
+/// ```
+class OpValidator {
+  OpValidator._();
+
+  /// Validates that tensor rank is within the specified range.
+  ///
+  /// Throws [ShapeMismatchException] if rank is outside [minRank, maxRank].
+  ///
+  /// Example:
+  /// ```dart
+  /// OpValidator.validateRank(shape, minRank: 3, maxRank: 4, operationName: 'PadOp');
+  /// ```
+  static void validateRank(
+    List<int> shape, {
+    required int minRank,
+    required int maxRank,
+    required String operationName,
+  }) {
+    final rank = shape.length;
+    if (rank < minRank || rank > maxRank) {
+      final rankRange = minRank == maxRank ? '$minRank' : '$minRank-$maxRank';
+      throw ShapeMismatchException(
+        actual: shape,
+        message: '$operationName requires ${rankRange}D tensor, got ${rank}D',
+      );
+    }
+  }
+
+  /// Validates and normalizes an axis value (supports negative indexing).
+  ///
+  /// Returns the normalized (positive) axis value.
+  /// Throws [IndexOutOfBoundsException] if axis is out of range.
+  ///
+  /// Example:
+  /// ```dart
+  /// final normalizedAxis = OpValidator.validateAxis(-1, rank: 4, operationName: 'SoftmaxOp');
+  /// // Returns 3 for a 4D tensor
+  /// ```
+  static int validateAxis(
+    int axis, {
+    required int rank,
+    required String operationName,
+  }) {
+    final normalizedAxis = axis < 0 ? rank + axis : axis;
+    if (normalizedAxis < 0 || normalizedAxis >= rank) {
+      throw IndexOutOfBoundsException(
+        index: axis,
+        min: -rank,
+        max: rank - 1,
+        dimension: '$operationName axis',
+      );
+    }
+    return normalizedAxis;
+  }
+
+  /// Validates that the channel count matches the expected value.
+  ///
+  /// Throws [ShapeMismatchException] if channels don't match.
+  ///
+  /// Example:
+  /// ```dart
+  /// OpValidator.validateChannels(
+  ///   shape[channelDim],
+  ///   expected: mean.length,
+  ///   operationName: 'NormalizeOp',
+  /// );
+  /// ```
+  static void validateChannels(
+    int actual, {
+    required int expected,
+    required String operationName,
+  }) {
+    if (actual != expected) {
+      throw ShapeMismatchException(
+        actual: [actual],
+        message:
+            '$operationName: channel count mismatch. Expected $expected, got $actual',
+      );
+    }
+  }
+
+  /// Validates that a dimension is positive.
+  ///
+  /// Throws [InvalidParameterException] if dimension is not positive.
+  static void validatePositiveDimension(
+    int value, {
+    required String paramName,
+    required String operationName,
+  }) {
+    if (value <= 0) {
+      throw InvalidParameterException(
+        paramName,
+        value,
+        '$operationName: $paramName must be positive',
+      );
+    }
+  }
+
+  /// Validates that a list has the expected length.
+  ///
+  /// Throws [InvalidParameterException] if lengths don't match.
+  static void validateListLength(
+    List<dynamic> list, {
+    required int expectedLength,
+    required String paramName,
+    required String operationName,
+  }) {
+    if (list.length != expectedLength) {
+      throw InvalidParameterException(
+        paramName,
+        list.length,
+        '$operationName: $paramName must have length $expectedLength, got ${list.length}',
+      );
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tensor_preprocessing
 description: >-
   High-performance tensor preprocessing library for Flutter/Dart.
   NumPy-like transforms pipeline for ONNX Runtime inference.
-version: 0.6.1
+version: 0.6.2
 repository: https://github.com/brody-0125/dart_tensor_preprocessing
 homepage: https://github.com/brody-0125/dart_tensor_preprocessing
 


### PR DESCRIPTION
- **TensorBuffer Factory Separation** - Moved factory methods to separate file:
  - `tensor_buffer_factory.dart` contains: zeros, ones, full, random, randn, eye, linspace, arange, fromFloat32List, fromFloat64List, fromUint8List
  - Reduces `tensor_buffer.dart` from ~840 lines to ~530 lines
  - No API changes
- **OpValidator** - Added centralized operation validation (`validation_utils.dart`):
  - `OpValidator.validateRank()` - Validates tensor rank range
  - `OpValidator.validateAxis()` - Validates and normalizes axis (supports negative indexing)
  - `OpValidator.validateChannels()` - Validates channel count
  - `OpValidator.validatePositiveDimension()` - Validates positive dimension
  - `OpValidator.validateListLength()` - Validates list length
- **OperationCapabilities** - Added operation metadata (`transform_op.dart`):
  - `supportsInPlace` - Whether op can modify tensor in place
  - `requiresContiguous` - Whether op requires contiguous memory
  - `preservesShape` - Whether op preserves input shape
  - `modifiesDType` - Whether op may change data type
  - Default `capabilities` getter on `TransformOp`