### PR TITLE
refactor: Uninitialized Buffer Factory for Memory Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-01-28
+
+### Added
+
+- **`TensorBuffer.uninitialized()` factory** - Creates tensor buffer without zero-fill for cases where all elements will be immediately overwritten
+  - Supports all DTypes and MemoryFormat options
+  - Semantically signals intent to overwrite, avoiding redundant initialization
+
+### Changed
+
+- **Uninitialized buffer usage** - Operations that fully overwrite output now use `TensorBuffer.uninitialized()` instead of `zeros()`:
+  - `ResizeOp` (3D/4D), `CenterCropOp` (3D/4D), `concat()`, `SliceOp`, `RandomCropOp` (3D/4D), `GaussianBlurOp` (3D/4D), `PadOp` (all modes)
+
+- **BufferPool integration in GaussianBlurOp** - Temporary `Float64List` buffers now acquired from `BufferPool` and properly released via `try/finally` to prevent leaks on exceptions
+
 ## [0.6.2] - 2026-01-20
 
 ### Internal

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tensor preprocessing library for Flutter/Dart. NumPy-like transforms pipeline fo
 
 ```yaml
 dependencies:
-  dart_tensor_preprocessing: ^0.6.2
+  dart_tensor_preprocessing: ^0.6.3
 ```
 
 ## Quick Start

--- a/lib/src/core/tensor_buffer.dart
+++ b/lib/src/core/tensor_buffer.dart
@@ -147,7 +147,8 @@ class TensorBuffer {
     if (newNumel != numel) {
       throw ShapeMismatchException(
         actual: newShape,
-        message: 'Cannot reshape tensor of size $numel to $newShape (size $newNumel)',
+        message:
+            'Cannot reshape tensor of size $numel to $newShape (size $newNumel)',
       );
     }
 
@@ -343,6 +344,17 @@ class TensorBuffer {
 
     return storage.getAsDouble(offset);
   }
+
+  /// Creates a tensor buffer without initializing values.
+  ///
+  /// WARNING: The buffer contains undefined values until written.
+  /// Only use when you will immediately write all elements.
+  static TensorBuffer uninitialized(
+    List<int> shape, {
+    DType dtype = DType.float32,
+    MemoryFormat memoryFormat = MemoryFormat.contiguous,
+  }) =>
+      _uninitializedImpl(shape, dtype: dtype, memoryFormat: memoryFormat);
 
   /// Creates a tensor filled with zeros.
   static TensorBuffer zeros(

--- a/lib/src/core/tensor_buffer_factory.dart
+++ b/lib/src/core/tensor_buffer_factory.dart
@@ -25,6 +25,26 @@ extension TensorBufferFactory on TensorBuffer {
 // Note: The following are implemented as static methods on TensorBuffer
 // in the main tensor_buffer.dart file, but their implementations are here.
 
+/// Creates a tensor buffer without initializing values.
+///
+/// In Dart, typed data buffers are zero-initialized by the VM,
+/// so this is functionally equivalent to [_zerosImpl]. The semantic
+/// distinction signals intent: the caller will overwrite all elements.
+TensorBuffer _uninitializedImpl(
+  List<int> shape, {
+  DType dtype = DType.float32,
+  MemoryFormat memoryFormat = MemoryFormat.contiguous,
+}) {
+  TensorBuffer._validateShapeStatic(shape);
+  final numel = shape.fold(1, (a, b) => a * b);
+  final data = dtype.createBuffer(numel);
+  return TensorBuffer(
+    storage: TensorStorage(data, dtype),
+    shape: List.unmodifiable(shape),
+    memoryFormat: memoryFormat,
+  );
+}
+
 /// Creates a tensor filled with zeros.
 TensorBuffer _zerosImpl(
   List<int> shape, {

--- a/lib/src/ops/augmentation_op.dart
+++ b/lib/src/ops/augmentation_op.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'dart:typed_data';
 
+import '../core/buffer_pool.dart';
 import '../core/dtype.dart';
 import '../core/tensor_buffer.dart';
 import '../exceptions/tensor_exceptions.dart';
@@ -84,7 +85,8 @@ class RandomCropOp extends TransformOp with RequiresContiguous {
     if (inputShape.length == 3) {
       // 3D: [C, H, W]
       final (c, h, w) = (inputShape[0], inputShape[1], inputShape[2]);
-      final output = TensorBuffer.zeros([c, height, width], dtype: input.dtype);
+      final output =
+          TensorBuffer.uninitialized([c, height, width], dtype: input.dtype);
 
       for (int ch = 0; ch < c; ch++) {
         for (int row = 0; row < height; row++) {
@@ -103,7 +105,7 @@ class RandomCropOp extends TransformOp with RequiresContiguous {
       final (n, c, h, w) =
           (inputShape[0], inputShape[1], inputShape[2], inputShape[3]);
       final output =
-          TensorBuffer.zeros([n, c, height, width], dtype: input.dtype);
+          TensorBuffer.uninitialized([n, c, height, width], dtype: input.dtype);
 
       for (int batch = 0; batch < n; batch++) {
         for (int ch = 0; ch < c; ch++) {
@@ -235,90 +237,18 @@ class GaussianBlurOp extends TransformOp with RequiresContiguous {
     if (inputShape.length == 3) {
       // 3D: [C, H, W]
       final (c, h, w) = (inputShape[0], inputShape[1], inputShape[2]);
-      final output = TensorBuffer.zeros([c, h, w], dtype: input.dtype);
+      final output = TensorBuffer.uninitialized([c, h, w], dtype: input.dtype);
 
-      // Pre-allocate temp buffer (reused across channels)
-      final temp = Float64List(h * w);
-
-      // Dtype-specialized for hot path optimization
-      switch (input.dtype) {
-        case DType.float32:
-          final inList = input.storage.data as Float32List;
-          final outList = output.storage.data as Float32List;
-          for (int ch = 0; ch < c; ch++) {
-            final chOffset = ch * h * w;
-            // Horizontal pass
-            for (int row = 0; row < h; row++) {
-              for (int col = 0; col < w; col++) {
-                double sum = 0.0;
-                for (int k = 0; k < kernelSize; k++) {
-                  final xi = reflectIndex(col + k - radius, w);
-                  sum += inList[chOffset + row * w + xi] * kernel[k];
-                }
-                temp[row * w + col] = sum;
-              }
-            }
-            // Vertical pass
-            for (int row = 0; row < h; row++) {
-              for (int col = 0; col < w; col++) {
-                double sum = 0.0;
-                for (int k = 0; k < kernelSize; k++) {
-                  final yi = reflectIndex(row + k - radius, h);
-                  sum += temp[yi * w + col] * kernel[k];
-                }
-                outList[chOffset + row * w + col] = sum;
-              }
-            }
-          }
-        default:
-          // Generic fallback
-          for (int ch = 0; ch < c; ch++) {
-            // Horizontal pass
-            for (int row = 0; row < h; row++) {
-              for (int col = 0; col < w; col++) {
-                double sum = 0.0;
-                for (int k = 0; k < kernelSize; k++) {
-                  final xi = reflectIndex(col + k - radius, w);
-                  final inputIdx = ch * h * w + row * w + xi;
-                  sum += input.storage.getAsDouble(inputIdx) * kernel[k];
-                }
-                temp[row * w + col] = sum;
-              }
-            }
-            // Vertical pass
-            for (int row = 0; row < h; row++) {
-              for (int col = 0; col < w; col++) {
-                double sum = 0.0;
-                for (int k = 0; k < kernelSize; k++) {
-                  final yi = reflectIndex(row + k - radius, h);
-                  sum += temp[yi * w + col] * kernel[k];
-                }
-                final outputIdx = ch * h * w + row * w + col;
-                output.storage.setFromDouble(outputIdx, sum);
-              }
-            }
-          }
-      }
-
-      return output;
-    } else {
-      // 4D: [N, C, H, W]
-      final (n, c, h, w) =
-          (inputShape[0], inputShape[1], inputShape[2], inputShape[3]);
-      final output = TensorBuffer.zeros([n, c, h, w], dtype: input.dtype);
-
-      // Pre-allocate temp buffer (reused across batches and channels)
-      final temp = Float64List(h * w);
-
-      // Dtype-specialized for hot path optimization
-      switch (input.dtype) {
-        case DType.float32:
-          final inList = input.storage.data as Float32List;
-          final outList = output.storage.data as Float32List;
-          for (int batch = 0; batch < n; batch++) {
-            final batchOffset = batch * c * h * w;
+      // Acquire pooled temp buffer (reused across channels)
+      final temp = BufferPool.instance.acquireFloat64(h * w);
+      try {
+        // Dtype-specialized for hot path optimization
+        switch (input.dtype) {
+          case DType.float32:
+            final inList = input.storage.data as Float32List;
+            final outList = output.storage.data as Float32List;
             for (int ch = 0; ch < c; ch++) {
-              final chOffset = batchOffset + ch * h * w;
+              final chOffset = ch * h * w;
               // Horizontal pass
               for (int row = 0; row < h; row++) {
                 for (int col = 0; col < w; col++) {
@@ -342,10 +272,8 @@ class GaussianBlurOp extends TransformOp with RequiresContiguous {
                 }
               }
             }
-          }
-        default:
-          // Generic fallback
-          for (int batch = 0; batch < n; batch++) {
+          default:
+            // Generic fallback
             for (int ch = 0; ch < c; ch++) {
               // Horizontal pass
               for (int row = 0; row < h; row++) {
@@ -353,8 +281,7 @@ class GaussianBlurOp extends TransformOp with RequiresContiguous {
                   double sum = 0.0;
                   for (int k = 0; k < kernelSize; k++) {
                     final xi = reflectIndex(col + k - radius, w);
-                    final inputIdx =
-                        batch * c * h * w + ch * h * w + row * w + xi;
+                    final inputIdx = ch * h * w + row * w + xi;
                     sum += input.storage.getAsDouble(inputIdx) * kernel[k];
                   }
                   temp[row * w + col] = sum;
@@ -368,19 +295,98 @@ class GaussianBlurOp extends TransformOp with RequiresContiguous {
                     final yi = reflectIndex(row + k - radius, h);
                     sum += temp[yi * w + col] * kernel[k];
                   }
-                  final outputIdx =
-                      batch * c * h * w + ch * h * w + row * w + col;
+                  final outputIdx = ch * h * w + row * w + col;
                   output.storage.setFromDouble(outputIdx, sum);
                 }
               }
             }
-          }
+        }
+      } finally {
+        BufferPool.instance.release(temp);
       }
+      return output;
+    } else {
+      // 4D: [N, C, H, W]
+      final (n, c, h, w) =
+          (inputShape[0], inputShape[1], inputShape[2], inputShape[3]);
+      final output =
+          TensorBuffer.uninitialized([n, c, h, w], dtype: input.dtype);
 
+      // Acquire pooled temp buffer (reused across batches and channels)
+      final temp = BufferPool.instance.acquireFloat64(h * w);
+      try {
+        // Dtype-specialized for hot path optimization
+        switch (input.dtype) {
+          case DType.float32:
+            final inList = input.storage.data as Float32List;
+            final outList = output.storage.data as Float32List;
+            for (int batch = 0; batch < n; batch++) {
+              final batchOffset = batch * c * h * w;
+              for (int ch = 0; ch < c; ch++) {
+                final chOffset = batchOffset + ch * h * w;
+                // Horizontal pass
+                for (int row = 0; row < h; row++) {
+                  for (int col = 0; col < w; col++) {
+                    double sum = 0.0;
+                    for (int k = 0; k < kernelSize; k++) {
+                      final xi = reflectIndex(col + k - radius, w);
+                      sum += inList[chOffset + row * w + xi] * kernel[k];
+                    }
+                    temp[row * w + col] = sum;
+                  }
+                }
+                // Vertical pass
+                for (int row = 0; row < h; row++) {
+                  for (int col = 0; col < w; col++) {
+                    double sum = 0.0;
+                    for (int k = 0; k < kernelSize; k++) {
+                      final yi = reflectIndex(row + k - radius, h);
+                      sum += temp[yi * w + col] * kernel[k];
+                    }
+                    outList[chOffset + row * w + col] = sum;
+                  }
+                }
+              }
+            }
+          default:
+            // Generic fallback
+            for (int batch = 0; batch < n; batch++) {
+              for (int ch = 0; ch < c; ch++) {
+                // Horizontal pass
+                for (int row = 0; row < h; row++) {
+                  for (int col = 0; col < w; col++) {
+                    double sum = 0.0;
+                    for (int k = 0; k < kernelSize; k++) {
+                      final xi = reflectIndex(col + k - radius, w);
+                      final inputIdx =
+                          batch * c * h * w + ch * h * w + row * w + xi;
+                      sum += input.storage.getAsDouble(inputIdx) * kernel[k];
+                    }
+                    temp[row * w + col] = sum;
+                  }
+                }
+                // Vertical pass
+                for (int row = 0; row < h; row++) {
+                  for (int col = 0; col < w; col++) {
+                    double sum = 0.0;
+                    for (int k = 0; k < kernelSize; k++) {
+                      final yi = reflectIndex(row + k - radius, h);
+                      sum += temp[yi * w + col] * kernel[k];
+                    }
+                    final outputIdx =
+                        batch * c * h * w + ch * h * w + row * w + col;
+                    output.storage.setFromDouble(outputIdx, sum);
+                  }
+                }
+              }
+            }
+        }
+      } finally {
+        BufferPool.instance.release(temp);
+      }
       return output;
     }
   }
-
 
   @override
   List<int> computeOutputShape(List<int> inputShape) => inputShape;

--- a/lib/src/ops/concat_op.dart
+++ b/lib/src/ops/concat_op.dart
@@ -79,7 +79,8 @@ TensorBuffer concat(List<TensorBuffer> tensors, {int axis = 0}) {
   outputShape[normalizedAxis] = totalAxisSize;
 
   // Create output tensor
-  final output = TensorBuffer.zeros(outputShape, dtype: firstTensor.dtype);
+  final output =
+      TensorBuffer.uninitialized(outputShape, dtype: firstTensor.dtype);
 
   // Optimized copy using linear indexing
   // For axis=0 and contiguous tensors, use bulk copy

--- a/lib/src/ops/pad_op.dart
+++ b/lib/src/ops/pad_op.dart
@@ -101,7 +101,8 @@ class PadOp extends TransformOp with RequiresContiguous {
     _validateShape(contiguous.shape);
 
     final outputShape = computeOutputShape(contiguous.shape);
-    final output = TensorBuffer.zeros(outputShape, dtype: contiguous.dtype);
+    final output =
+        TensorBuffer.uninitialized(outputShape, dtype: contiguous.dtype);
 
     switch (mode) {
       case PadMode.constant:
@@ -364,7 +365,6 @@ class PadOp extends TransformOp with RequiresContiguous {
       }
     }
   }
-
 
   @override
   List<int> computeOutputShape(List<int> inputShape) {

--- a/lib/src/ops/resize_op.dart
+++ b/lib/src/ops/resize_op.dart
@@ -101,7 +101,7 @@ class ResizeOp extends TransformOp with RequiresContiguous {
     final srcW = input.shape[2];
 
     final outputShape = [c, height, width];
-    final output = TensorBuffer.zeros(outputShape, dtype: input.dtype);
+    final output = TensorBuffer.uninitialized(outputShape, dtype: input.dtype);
 
     _resizeChannels(
       input: input,
@@ -123,7 +123,7 @@ class ResizeOp extends TransformOp with RequiresContiguous {
     final srcW = input.shape[3];
 
     final outputShape = [n, c, height, width];
-    final output = TensorBuffer.zeros(outputShape, dtype: input.dtype);
+    final output = TensorBuffer.uninitialized(outputShape, dtype: input.dtype);
 
     final srcBatchStride = c * srcH * srcW;
     final dstBatchStride = c * height * width;
@@ -446,8 +446,7 @@ class ResizeOp extends TransformOp with RequiresContiguous {
               for (int i = -1; i <= 2; i++) {
                 final xi = (x0 + i).clamp(0, srcW - 1);
                 final wx = _cubicWeight(i - fx);
-                final v =
-                    input.storage.getAsDouble(srcOffset + yj * srcW + xi);
+                final v = input.storage.getAsDouble(srcOffset + yj * srcW + xi);
                 value += v * wx * wy;
               }
             }
@@ -667,8 +666,7 @@ class ResizeOp extends TransformOp with RequiresContiguous {
                 final wx = _lanczosKernel(i - fx, a);
                 final weight = wx * wy;
 
-                final v =
-                    input.storage.getAsDouble(srcOffset + yj * srcW + xi);
+                final v = input.storage.getAsDouble(srcOffset + yj * srcW + xi);
                 value += v * weight;
                 weightSum += weight;
               }
@@ -839,7 +837,8 @@ class CenterCropOp extends TransformOp with RequiresContiguous {
     final srcH = input.shape[1];
     final srcW = input.shape[2];
 
-    final output = TensorBuffer.zeros([c, height, width], dtype: input.dtype);
+    final output =
+        TensorBuffer.uninitialized([c, height, width], dtype: input.dtype);
 
     // Dtype-specialized for hot path optimization
     switch (input.dtype) {
@@ -885,7 +884,7 @@ class CenterCropOp extends TransformOp with RequiresContiguous {
     final srcW = input.shape[3];
 
     final output =
-        TensorBuffer.zeros([n, c, height, width], dtype: input.dtype);
+        TensorBuffer.uninitialized([n, c, height, width], dtype: input.dtype);
 
     final srcBatchStride = c * srcH * srcW;
     final dstBatchStride = c * height * width;
@@ -923,8 +922,10 @@ class CenterCropOp extends TransformOp with RequiresContiguous {
                     ch * srcChannelStride +
                     (startY + y) * srcW +
                     (startX + x);
-                final dstIdx =
-                    batch * dstBatchStride + ch * dstChannelStride + y * width + x;
+                final dstIdx = batch * dstBatchStride +
+                    ch * dstChannelStride +
+                    y * width +
+                    x;
                 final value = input.storage.getAsDouble(srcIdx);
                 output.storage.setFromDouble(dstIdx, value);
               }

--- a/lib/src/ops/slice_op.dart
+++ b/lib/src/ops/slice_op.dart
@@ -102,7 +102,7 @@ class SliceOp extends TransformOp {
     }).toList();
 
     // Create output tensor
-    final output = TensorBuffer.zeros(outputShape, dtype: input.dtype);
+    final output = TensorBuffer.uninitialized(outputShape, dtype: input.dtype);
 
     // Copy data using the slice ranges
     _copySlicedData(input, output, ranges);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tensor_preprocessing
 description: >-
   High-performance tensor preprocessing library for Flutter/Dart.
   NumPy-like transforms pipeline for ONNX Runtime inference.
-version: 0.6.2
+version: 0.6.3
 repository: https://github.com/brody-0125/dart_tensor_preprocessing
 homepage: https://github.com/brody-0125/dart_tensor_preprocessing
 

--- a/test/tensor_factory_test.dart
+++ b/test/tensor_factory_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:dart_tensor_preprocessing/src/core/dtype.dart';
+import 'package:dart_tensor_preprocessing/src/core/memory_format.dart';
 import 'package:dart_tensor_preprocessing/src/core/tensor_buffer.dart';
 import 'package:dart_tensor_preprocessing/src/exceptions/tensor_exceptions.dart';
 
@@ -33,8 +34,10 @@ void main() {
     });
 
     test('supports different dtypes', () {
-      final tensorFloat = TensorBuffer.full([2], fillValue: 3.0, dtype: DType.float32);
-      final tensorInt = TensorBuffer.full([2], fillValue: 3.0, dtype: DType.int32);
+      final tensorFloat =
+          TensorBuffer.full([2], fillValue: 3.0, dtype: DType.float32);
+      final tensorInt =
+          TensorBuffer.full([2], fillValue: 3.0, dtype: DType.int32);
 
       expect(tensorFloat.dtype, equals(DType.float32));
       expect(tensorInt.dtype, equals(DType.int32));
@@ -265,6 +268,48 @@ void main() {
         () => TensorBuffer.arange(start: 5.0, end: 0.0, step: 1.0),
         throwsA(isA<InvalidParameterException>()),
       );
+    });
+  });
+
+  group('TensorBuffer.uninitialized', () {
+    test('creates tensor with correct shape and dtype', () {
+      final tensor = TensorBuffer.uninitialized([2, 3]);
+
+      expect(tensor.shape, equals([2, 3]));
+      expect(tensor.numel, equals(6));
+      expect(tensor.dtype, equals(DType.float32));
+    });
+
+    test('supports float64 dtype', () {
+      final tensor = TensorBuffer.uninitialized([3, 4], dtype: DType.float64);
+
+      expect(tensor.shape, equals([3, 4]));
+      expect(tensor.dtype, equals(DType.float64));
+      expect(tensor.numel, equals(12));
+    });
+
+    test('supports uint8 dtype', () {
+      final tensor = TensorBuffer.uninitialized([2, 2], dtype: DType.uint8);
+
+      expect(tensor.shape, equals([2, 2]));
+      expect(tensor.dtype, equals(DType.uint8));
+    });
+
+    test('validates shape', () {
+      expect(
+        () => TensorBuffer.uninitialized([-1, 3]),
+        throwsA(isA<InvalidParameterException>()),
+      );
+    });
+
+    test('supports memory format parameter', () {
+      final tensor = TensorBuffer.uninitialized(
+        [1, 3, 4, 4],
+        memoryFormat: MemoryFormat.channelsLast,
+      );
+
+      expect(tensor.shape, equals([1, 3, 4, 4]));
+      expect(tensor.memoryFormat, equals(MemoryFormat.channelsLast));
     });
   });
 }


### PR DESCRIPTION
### Added
- **`TensorBuffer.uninitialized()` factory** - Creates tensor buffer without zero-fill for cases where all elements will be immediately overwritten
  - Supports all DTypes and MemoryFormat options
  - Semantically signals intent to overwrite, avoiding redundant initialization
### Changed
- **Uninitialized buffer usage** - Operations that fully overwrite output now use `TensorBuffer.uninitialized()` instead of `zeros()`:
  - `ResizeOp` (3D/4D), `CenterCropOp` (3D/4D), `concat()`, `SliceOp`, `RandomCropOp` (3D/4D), `GaussianBlurOp` (3D/4D), `PadOp` (all modes)
- **BufferPool integration in GaussianBlurOp** - Temporary `Float64List` buffers now acquired from `BufferPool` and properly released via `try/finally` to prevent leaks on exceptions