### PR TITLE
Add argmax/argmin operations for tensor index reduction

### DIFF
--- a/lib/dart_tensor_preprocessing.dart
+++ b/lib/dart_tensor_preprocessing.dart
@@ -71,6 +71,7 @@ export 'src/ops/roll_op.dart';
 export 'src/ops/split_op.dart';
 export 'src/ops/tile_op.dart';
 export 'src/ops/topk_op.dart';
+export 'src/ops/argmax_op.dart';
 export 'src/ops/where_op.dart';
 export 'src/pipeline/tensor_pipeline.dart';
 export 'src/pipeline/presets.dart';

--- a/lib/src/core/tensor_buffer_reduce.dart
+++ b/lib/src/core/tensor_buffer_reduce.dart
@@ -568,6 +568,7 @@ extension TensorBufferReduce on TensorBuffer {
     // Compute reductions
     final axisSize = shape[normalizedAxis];
     final outputIndices = List<int>.filled(outputShape.length, 0);
+    final inputIndices = List<int>.filled(rank, 0);
 
     for (int outIdx = 0; outIdx < outputNumel; outIdx++) {
       // Collect values along the reduction axis
@@ -575,14 +576,13 @@ extension TensorBufferReduce on TensorBuffer {
 
       for (int axisIdx = 0; axisIdx < axisSize; axisIdx++) {
         // Build input indices from output indices
-        final inputIndices = <int>[];
         int outDim = 0;
         for (int d = 0; d < rank; d++) {
           if (d == normalizedAxis) {
-            inputIndices.add(axisIdx);
-            if (keepDims) outDim++; // Skip the size-1 dimension in output
+            inputIndices[d] = axisIdx;
+            if (keepDims) outDim++;
           } else {
-            inputIndices.add(outputIndices[outDim]);
+            inputIndices[d] = outputIndices[outDim];
             outDim++;
           }
         }

--- a/lib/src/core/tensor_buffer_reduce.dart
+++ b/lib/src/core/tensor_buffer_reduce.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
 import '../exceptions/tensor_exceptions.dart';
+import 'dtype.dart';
 import 'tensor_buffer.dart';
+import 'tensor_storage.dart';
 
 /// Extension providing reduction operations for [TensorBuffer].
 ///
@@ -100,6 +102,70 @@ extension TensorBufferReduce on TensorBuffer {
     return result;
   }
 
+  /// Returns the flat index of the maximum value in this tensor.
+  ///
+  /// If multiple elements have the maximum value, the index of the first
+  /// occurrence (in row-major order) is returned.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5]),
+  ///   [5],
+  /// );
+  /// print(tensor.argmax()); // 4
+  /// ```
+  int argmax() {
+    double maxVal = double.negativeInfinity;
+    int maxIdx = 0;
+    final indices = List<int>.filled(rank, 0);
+
+    for (int i = 0; i < numel; i++) {
+      int offset = storageOffset;
+      for (int d = 0; d < rank; d++) {
+        offset += indices[d] * strides[d];
+      }
+      final value = storage.getAsDouble(offset);
+      if (value > maxVal) {
+        maxVal = value;
+        maxIdx = i;
+      }
+      _incrementIndices(indices);
+    }
+    return maxIdx;
+  }
+
+  /// Returns the flat index of the minimum value in this tensor.
+  ///
+  /// If multiple elements have the minimum value, the index of the first
+  /// occurrence (in row-major order) is returned.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5]),
+  ///   [5],
+  /// );
+  /// print(tensor.argmin()); // 1
+  /// ```
+  int argmin() {
+    double minVal = double.infinity;
+    int minIdx = 0;
+    final indices = List<int>.filled(rank, 0);
+
+    for (int i = 0; i < numel; i++) {
+      int offset = storageOffset;
+      for (int d = 0; d < rank; d++) {
+        offset += indices[d] * strides[d];
+      }
+      final value = storage.getAsDouble(offset);
+      if (value < minVal) {
+        minVal = value;
+        minIdx = i;
+      }
+      _incrementIndices(indices);
+    }
+    return minIdx;
+  }
+
   /// Increments multi-dimensional indices in row-major order.
   void _incrementIndices(List<int> indices) {
     for (int d = rank - 1; d >= 0; d--) {
@@ -184,6 +250,56 @@ extension TensorBufferReduce on TensorBuffer {
   /// ```
   TensorBuffer maxAxis(int axis, {bool keepDims = false}) {
     return _reduceAxis(axis, keepDims: keepDims, reduce: _maxReduce);
+  }
+
+  // ============================================================
+  // Argmax / Argmin Axis Reductions
+  // ============================================================
+
+  /// Returns a tensor of indices of maximum values along the specified [axis].
+  ///
+  /// The output dtype is always [DType.int64]. If [keepDims] is true, the
+  /// reduced dimension is retained with size 1.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5, 9]),
+  ///   [2, 3],
+  /// );
+  /// // Argmax along axis 1: [argmax(3,1,4), argmax(1,5,9)] = [2, 2]
+  /// final result = tensor.argmaxAxis(1);
+  /// print(result.toList()); // [2, 2]
+  /// print(result.dtype); // DType.int64
+  /// ```
+  TensorBuffer argmaxAxis(int axis, {bool keepDims = false}) {
+    return _reduceAxisToIndex(
+      axis,
+      keepDims: keepDims,
+      indexReduce: _argmaxReduce,
+    );
+  }
+
+  /// Returns a tensor of indices of minimum values along the specified [axis].
+  ///
+  /// The output dtype is always [DType.int64]. If [keepDims] is true, the
+  /// reduced dimension is retained with size 1.
+  ///
+  /// ```dart
+  /// final tensor = TensorBuffer.fromFloat32List(
+  ///   Float32List.fromList([3, 1, 4, 1, 5, 9]),
+  ///   [2, 3],
+  /// );
+  /// // Argmin along axis 1: [argmin(3,1,4), argmin(1,5,9)] = [1, 0]
+  /// final result = tensor.argminAxis(1);
+  /// print(result.toList()); // [1, 0]
+  /// print(result.dtype); // DType.int64
+  /// ```
+  TensorBuffer argminAxis(int axis, {bool keepDims = false}) {
+    return _reduceAxisToIndex(
+      axis,
+      keepDims: keepDims,
+      indexReduce: _argminReduce,
+    );
   }
 
   // ============================================================
@@ -394,6 +510,108 @@ extension TensorBufferReduce on TensorBuffer {
     return TensorBuffer.fromFloat32List(outputData, outputShape);
   }
 
+  /// Generic single-axis index-reduction implementation.
+  ///
+  /// Similar to [_reduceAxis] but returns the index of the selected element
+  /// rather than the value. Output dtype is always [DType.int64].
+  TensorBuffer _reduceAxisToIndex(
+    int axis, {
+    required bool keepDims,
+    required int Function(List<double>) indexReduce,
+  }) {
+    // Normalize negative axis
+    final normalizedAxis = axis < 0 ? rank + axis : axis;
+
+    if (normalizedAxis < 0 || normalizedAxis >= rank) {
+      throw IndexOutOfBoundsException(
+        index: axis,
+        min: -rank,
+        max: rank - 1,
+        dimension: 'axis',
+      );
+    }
+
+    // Compute output shape
+    final outputShape = <int>[];
+    for (int d = 0; d < rank; d++) {
+      if (d == normalizedAxis) {
+        if (keepDims) outputShape.add(1);
+      } else {
+        outputShape.add(shape[d]);
+      }
+    }
+
+    // Handle scalar result (1D tensor reduced without keepDims)
+    if (outputShape.isEmpty) {
+      final values = <double>[];
+      final indices = List<int>.filled(rank, 0);
+      for (int i = 0; i < numel; i++) {
+        int offset = storageOffset;
+        for (int d = 0; d < rank; d++) {
+          offset += indices[d] * strides[d];
+        }
+        values.add(storage.getAsDouble(offset));
+        _incrementIndices(indices);
+      }
+      final resultIndex = indexReduce(values);
+      final outputData = Int64List.fromList([resultIndex]);
+      return TensorBuffer(
+        storage: TensorStorage(outputData, DType.int64),
+        shape: [1],
+      );
+    }
+
+    // Create output buffer
+    final outputNumel = outputShape.fold(1, (a, b) => a * b);
+    final outputData = Int64List(outputNumel);
+
+    // Compute reductions
+    final axisSize = shape[normalizedAxis];
+    final outputIndices = List<int>.filled(outputShape.length, 0);
+
+    for (int outIdx = 0; outIdx < outputNumel; outIdx++) {
+      // Collect values along the reduction axis
+      final values = <double>[];
+
+      for (int axisIdx = 0; axisIdx < axisSize; axisIdx++) {
+        // Build input indices from output indices
+        final inputIndices = <int>[];
+        int outDim = 0;
+        for (int d = 0; d < rank; d++) {
+          if (d == normalizedAxis) {
+            inputIndices.add(axisIdx);
+            if (keepDims) outDim++; // Skip the size-1 dimension in output
+          } else {
+            inputIndices.add(outputIndices[outDim]);
+            outDim++;
+          }
+        }
+
+        // Compute offset and get value
+        int offset = storageOffset;
+        for (int d = 0; d < rank; d++) {
+          offset += inputIndices[d] * strides[d];
+        }
+        values.add(storage.getAsDouble(offset));
+      }
+
+      // Apply index reduction and store result
+      outputData[outIdx] = indexReduce(values);
+
+      // Increment output indices
+      for (int d = outputShape.length - 1; d >= 0; d--) {
+        outputIndices[d]++;
+        if (outputIndices[d] < outputShape[d]) break;
+        outputIndices[d] = 0;
+      }
+    }
+
+    return TensorBuffer(
+      storage: TensorStorage(outputData, DType.int64),
+      shape: outputShape,
+    );
+  }
+
   // ============================================================
   // Data Extraction
   // ============================================================
@@ -458,4 +676,28 @@ double _maxReduce(List<double> values) {
     if (v > result) result = v;
   }
   return result;
+}
+
+int _argmaxReduce(List<double> values) {
+  double maxVal = double.negativeInfinity;
+  int maxIdx = 0;
+  for (int i = 0; i < values.length; i++) {
+    if (values[i] > maxVal) {
+      maxVal = values[i];
+      maxIdx = i;
+    }
+  }
+  return maxIdx;
+}
+
+int _argminReduce(List<double> values) {
+  double minVal = double.infinity;
+  int minIdx = 0;
+  for (int i = 0; i < values.length; i++) {
+    if (values[i] < minVal) {
+      minVal = values[i];
+      minIdx = i;
+    }
+  }
+  return minIdx;
 }

--- a/lib/src/ops/argmax_op.dart
+++ b/lib/src/ops/argmax_op.dart
@@ -4,6 +4,42 @@ import '../core/tensor_buffer_reduce.dart';
 import '../exceptions/tensor_exceptions.dart';
 import 'transform_op.dart';
 
+/// Base class for argmax/argmin operations that share axis reduction logic.
+abstract class _ArgReduceOp extends TransformOp {
+  /// The axis along which to find the extreme value. Supports negative indexing.
+  final int axis;
+
+  /// If `true`, the reduced dimension is retained with size 1.
+  final bool keepDims;
+
+  _ArgReduceOp({required this.axis, this.keepDims = false});
+
+  @override
+  List<int> computeOutputShape(List<int> inputShape) {
+    final rank = inputShape.length;
+    final normalizedAxis = axis < 0 ? rank + axis : axis;
+
+    if (normalizedAxis < 0 || normalizedAxis >= rank) {
+      throw IndexOutOfBoundsException(
+        index: axis,
+        min: -rank,
+        max: rank - 1,
+        dimension: '$name axis',
+      );
+    }
+
+    final outputShape = <int>[];
+    for (int d = 0; d < rank; d++) {
+      if (d == normalizedAxis) {
+        if (keepDims) outputShape.add(1);
+      } else {
+        outputShape.add(inputShape[d]);
+      }
+    }
+    return outputShape.isEmpty ? [1] : outputShape;
+  }
+}
+
 /// Selects the index of the maximum value along an axis.
 ///
 /// Equivalent to `torch.argmax()` in PyTorch and the ONNX `ArgMax` operator.
@@ -16,18 +52,12 @@ import 'transform_op.dart';
 /// final op = ArgMaxOp(axis: 1);
 /// final indices = op.apply(tensor); // DType.int64
 /// ```
-class ArgMaxOp extends TransformOp {
-  /// The axis along which to find the maximum. Supports negative indexing.
-  final int axis;
-
-  /// If `true`, the reduced dimension is retained with size 1.
-  final bool keepDims;
-
+class ArgMaxOp extends _ArgReduceOp {
   /// Creates an ArgMax operation.
   ///
   /// - [axis]: Axis along which to operate.
   /// - [keepDims]: Whether to retain the reduced dimension (default: `false`).
-  ArgMaxOp({required this.axis, this.keepDims = false});
+  ArgMaxOp({required super.axis, super.keepDims});
 
   @override
   String get name => 'ArgMax';
@@ -45,31 +75,6 @@ class ArgMaxOp extends TransformOp {
   TensorBuffer apply(TensorBuffer input) {
     return input.argmaxAxis(axis, keepDims: keepDims);
   }
-
-  @override
-  List<int> computeOutputShape(List<int> inputShape) {
-    final rank = inputShape.length;
-    final normalizedAxis = axis < 0 ? rank + axis : axis;
-
-    if (normalizedAxis < 0 || normalizedAxis >= rank) {
-      throw IndexOutOfBoundsException(
-        index: axis,
-        min: -rank,
-        max: rank - 1,
-        dimension: 'ArgMaxOp axis',
-      );
-    }
-
-    final outputShape = <int>[];
-    for (int d = 0; d < rank; d++) {
-      if (d == normalizedAxis) {
-        if (keepDims) outputShape.add(1);
-      } else {
-        outputShape.add(inputShape[d]);
-      }
-    }
-    return outputShape.isEmpty ? [1] : outputShape;
-  }
 }
 
 /// Selects the index of the minimum value along an axis.
@@ -84,18 +89,12 @@ class ArgMaxOp extends TransformOp {
 /// final op = ArgMinOp(axis: 1);
 /// final indices = op.apply(tensor); // DType.int64
 /// ```
-class ArgMinOp extends TransformOp {
-  /// The axis along which to find the minimum. Supports negative indexing.
-  final int axis;
-
-  /// If `true`, the reduced dimension is retained with size 1.
-  final bool keepDims;
-
+class ArgMinOp extends _ArgReduceOp {
   /// Creates an ArgMin operation.
   ///
   /// - [axis]: Axis along which to operate.
   /// - [keepDims]: Whether to retain the reduced dimension (default: `false`).
-  ArgMinOp({required this.axis, this.keepDims = false});
+  ArgMinOp({required super.axis, super.keepDims});
 
   @override
   String get name => 'ArgMin';
@@ -112,30 +111,5 @@ class ArgMinOp extends TransformOp {
   @override
   TensorBuffer apply(TensorBuffer input) {
     return input.argminAxis(axis, keepDims: keepDims);
-  }
-
-  @override
-  List<int> computeOutputShape(List<int> inputShape) {
-    final rank = inputShape.length;
-    final normalizedAxis = axis < 0 ? rank + axis : axis;
-
-    if (normalizedAxis < 0 || normalizedAxis >= rank) {
-      throw IndexOutOfBoundsException(
-        index: axis,
-        min: -rank,
-        max: rank - 1,
-        dimension: 'ArgMinOp axis',
-      );
-    }
-
-    final outputShape = <int>[];
-    for (int d = 0; d < rank; d++) {
-      if (d == normalizedAxis) {
-        if (keepDims) outputShape.add(1);
-      } else {
-        outputShape.add(inputShape[d]);
-      }
-    }
-    return outputShape.isEmpty ? [1] : outputShape;
   }
 }

--- a/lib/src/ops/argmax_op.dart
+++ b/lib/src/ops/argmax_op.dart
@@ -1,0 +1,141 @@
+import '../core/dtype.dart';
+import '../core/tensor_buffer.dart';
+import '../core/tensor_buffer_reduce.dart';
+import '../exceptions/tensor_exceptions.dart';
+import 'transform_op.dart';
+
+/// Selects the index of the maximum value along an axis.
+///
+/// Equivalent to `torch.argmax()` in PyTorch and the ONNX `ArgMax` operator.
+///
+/// The output shape is the same as the input shape with the specified axis
+/// removed (or retained with size 1 if [keepDims] is true). Output dtype
+/// is always [DType.int64].
+///
+/// ```dart
+/// final op = ArgMaxOp(axis: 1);
+/// final indices = op.apply(tensor); // DType.int64
+/// ```
+class ArgMaxOp extends TransformOp {
+  /// The axis along which to find the maximum. Supports negative indexing.
+  final int axis;
+
+  /// If `true`, the reduced dimension is retained with size 1.
+  final bool keepDims;
+
+  /// Creates an ArgMax operation.
+  ///
+  /// - [axis]: Axis along which to operate.
+  /// - [keepDims]: Whether to retain the reduced dimension (default: `false`).
+  ArgMaxOp({required this.axis, this.keepDims = false});
+
+  @override
+  String get name => 'ArgMax';
+
+  @override
+  OperationCapabilities get capabilities => const OperationCapabilities(
+    preservesShape: false,
+    modifiesDType: true,
+    pytorchEquivalent: 'torch.argmax',
+    onnxOpType: 'ArgMax',
+    onnxOpsetVersion: 13,
+  );
+
+  @override
+  TensorBuffer apply(TensorBuffer input) {
+    return input.argmaxAxis(axis, keepDims: keepDims);
+  }
+
+  @override
+  List<int> computeOutputShape(List<int> inputShape) {
+    final rank = inputShape.length;
+    final normalizedAxis = axis < 0 ? rank + axis : axis;
+
+    if (normalizedAxis < 0 || normalizedAxis >= rank) {
+      throw IndexOutOfBoundsException(
+        index: axis,
+        min: -rank,
+        max: rank - 1,
+        dimension: 'ArgMaxOp axis',
+      );
+    }
+
+    final outputShape = <int>[];
+    for (int d = 0; d < rank; d++) {
+      if (d == normalizedAxis) {
+        if (keepDims) outputShape.add(1);
+      } else {
+        outputShape.add(inputShape[d]);
+      }
+    }
+    return outputShape.isEmpty ? [1] : outputShape;
+  }
+}
+
+/// Selects the index of the minimum value along an axis.
+///
+/// Equivalent to `torch.argmin()` in PyTorch and the ONNX `ArgMin` operator.
+///
+/// The output shape is the same as the input shape with the specified axis
+/// removed (or retained with size 1 if [keepDims] is true). Output dtype
+/// is always [DType.int64].
+///
+/// ```dart
+/// final op = ArgMinOp(axis: 1);
+/// final indices = op.apply(tensor); // DType.int64
+/// ```
+class ArgMinOp extends TransformOp {
+  /// The axis along which to find the minimum. Supports negative indexing.
+  final int axis;
+
+  /// If `true`, the reduced dimension is retained with size 1.
+  final bool keepDims;
+
+  /// Creates an ArgMin operation.
+  ///
+  /// - [axis]: Axis along which to operate.
+  /// - [keepDims]: Whether to retain the reduced dimension (default: `false`).
+  ArgMinOp({required this.axis, this.keepDims = false});
+
+  @override
+  String get name => 'ArgMin';
+
+  @override
+  OperationCapabilities get capabilities => const OperationCapabilities(
+    preservesShape: false,
+    modifiesDType: true,
+    pytorchEquivalent: 'torch.argmin',
+    onnxOpType: 'ArgMin',
+    onnxOpsetVersion: 13,
+  );
+
+  @override
+  TensorBuffer apply(TensorBuffer input) {
+    return input.argminAxis(axis, keepDims: keepDims);
+  }
+
+  @override
+  List<int> computeOutputShape(List<int> inputShape) {
+    final rank = inputShape.length;
+    final normalizedAxis = axis < 0 ? rank + axis : axis;
+
+    if (normalizedAxis < 0 || normalizedAxis >= rank) {
+      throw IndexOutOfBoundsException(
+        index: axis,
+        min: -rank,
+        max: rank - 1,
+        dimension: 'ArgMinOp axis',
+      );
+    }
+
+    final outputShape = <int>[];
+    for (int d = 0; d < rank; d++) {
+      if (d == normalizedAxis) {
+        if (keepDims) outputShape.add(1);
+      } else {
+        outputShape.add(inputShape[d]);
+      }
+    }
+    return outputShape.isEmpty ? [1] : outputShape;
+  }
+}

--- a/test/argmax_argmin_test.dart
+++ b/test/argmax_argmin_test.dart
@@ -1,0 +1,420 @@
+// Argmax/argmin operations tests
+//
+// Tests cover:
+// - argmax(), argmin() for global (flat) index
+// - argmaxAxis(), argminAxis() for axis-wise index reduction
+// - ArgMaxOp, ArgMinOp TransformOp subclasses
+// - Different data types, non-contiguous tensors, keepDims, negative axis
+import 'dart:typed_data';
+
+import 'package:dart_tensor_preprocessing/dart_tensor_preprocessing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('argmax (global)', () {
+    test('1D tensor', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5]),
+        [5],
+      );
+      expect(tensor.argmax(), equals(4));
+    });
+
+    test('2D tensor', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3, 4, 5, 6]),
+        [2, 3],
+      );
+      // Flat index of max (6) is 5
+      expect(tensor.argmax(), equals(5));
+    });
+
+    test('single element', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([42]),
+        [1],
+      );
+      expect(tensor.argmax(), equals(0));
+    });
+
+    test('duplicate max returns first occurrence', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 5, 3, 5, 2]),
+        [5],
+      );
+      expect(tensor.argmax(), equals(1));
+    });
+
+    test('non-contiguous (transposed) tensor', () {
+      // Original [2,3]: [[1,2,3],[4,5,6]]
+      // Transposed [3,2]: [[1,4],[2,5],[3,6]]
+      // In logical order: 1,4,2,5,3,6 → max=6 at flat index 5
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3, 4, 5, 6]),
+        [2, 3],
+      );
+      final transposed = tensor.transpose([1, 0]);
+      expect(transposed.argmax(), equals(5));
+    });
+
+    test('negative values', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([-5, -3, -1, -4, -2]),
+        [5],
+      );
+      expect(tensor.argmax(), equals(2));
+    });
+  });
+
+  group('argmin (global)', () {
+    test('1D tensor', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5]),
+        [5],
+      );
+      expect(tensor.argmin(), equals(1));
+    });
+
+    test('2D tensor', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([6, 5, 4, 3, 2, 1]),
+        [2, 3],
+      );
+      // Flat index of min (1) is 5
+      expect(tensor.argmin(), equals(5));
+    });
+
+    test('single element', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([42]),
+        [1],
+      );
+      expect(tensor.argmin(), equals(0));
+    });
+
+    test('duplicate min returns first occurrence', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([5, 1, 3, 1, 2]),
+        [5],
+      );
+      expect(tensor.argmin(), equals(1));
+    });
+
+    test('non-contiguous (transposed) tensor', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 2, 1, 6, 5, 4]),
+        [2, 3],
+      );
+      final transposed = tensor.transpose([1, 0]);
+      // Transposed [3,2]: [[3,6],[2,5],[1,4]]
+      // Logical order: 3,6,2,5,1,4 → min=1 at flat index 4
+      expect(transposed.argmin(), equals(4));
+    });
+  });
+
+  group('argmaxAxis', () {
+    test('2D along axis 0', () {
+      // [[3,1,4],[1,5,9]]
+      // Along axis 0: argmax([3,1])=0, argmax([1,5])=1, argmax([4,9])=1
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final result = tensor.argmaxAxis(0);
+      expect(result.shape, equals([3]));
+      expect(result.toList(), equals([0, 1, 1]));
+    });
+
+    test('2D along axis 1', () {
+      // [[3,1,4],[1,5,9]]
+      // Along axis 1: argmax([3,1,4])=2, argmax([1,5,9])=2
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final result = tensor.argmaxAxis(1);
+      expect(result.shape, equals([2]));
+      expect(result.toList(), equals([2, 2]));
+    });
+
+    test('3D along axis 0', () {
+      // Shape [2,2,3]:
+      // [[[1,2,3],[4,5,6]],
+      //  [[7,8,9],[10,11,12]]]
+      // Along axis 0: compare [1,7]→1, [2,8]→1, ... all index 1
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        [2, 2, 3],
+      );
+      final result = tensor.argmaxAxis(0);
+      expect(result.shape, equals([2, 3]));
+      expect(result.toList(), equals([1, 1, 1, 1, 1, 1]));
+    });
+
+    test('3D along axis 2', () {
+      // Shape [2,2,3]:
+      // [[[1,2,3],[4,5,6]],
+      //  [[7,8,9],[10,11,12]]]
+      // Along axis 2: argmax([1,2,3])=2, argmax([4,5,6])=2, ...
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        [2, 2, 3],
+      );
+      final result = tensor.argmaxAxis(2);
+      expect(result.shape, equals([2, 2]));
+      expect(result.toList(), equals([2, 2, 2, 2]));
+    });
+
+    test('keepDims: true', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final result = tensor.argmaxAxis(1, keepDims: true);
+      expect(result.shape, equals([2, 1]));
+      expect(result.toList(), equals([2, 2]));
+    });
+
+    test('negative axis', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      // axis -1 == axis 1
+      final result = tensor.argmaxAxis(-1);
+      expect(result.shape, equals([2]));
+      expect(result.toList(), equals([2, 2]));
+    });
+
+    test('1D tensor (scalar result)', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5]),
+        [5],
+      );
+      final result = tensor.argmaxAxis(0);
+      expect(result.shape, equals([1]));
+      expect(result.toList(), equals([4]));
+    });
+
+    test('output dtype is int64', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3]),
+        [3],
+      );
+      final result = tensor.argmaxAxis(0);
+      expect(result.dtype, equals(DType.int64));
+    });
+
+    test('non-contiguous (transposed) tensor', () {
+      // Original [2,3]: [[1,2,3],[4,5,6]]
+      // Transposed [3,2]: [[1,4],[2,5],[3,6]]
+      // argmaxAxis(1): argmax([1,4])=1, argmax([2,5])=1, argmax([3,6])=1
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3, 4, 5, 6]),
+        [2, 3],
+      );
+      final transposed = tensor.transpose([1, 0]);
+      final result = transposed.argmaxAxis(1);
+      expect(result.shape, equals([3]));
+      expect(result.toList(), equals([1, 1, 1]));
+    });
+
+    test('uint8 input dtype', () {
+      final tensor = TensorBuffer(
+        storage: TensorStorage(Uint8List.fromList([10, 200, 50]), DType.uint8),
+        shape: [3],
+      );
+      final result = tensor.argmaxAxis(0);
+      expect(result.dtype, equals(DType.int64));
+      expect(result.toList(), equals([1]));
+    });
+
+    test('invalid axis throws IndexOutOfBoundsException', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3]),
+        [3],
+      );
+      expect(
+        () => tensor.argmaxAxis(1),
+        throwsA(isA<IndexOutOfBoundsException>()),
+      );
+    });
+  });
+
+  group('argminAxis', () {
+    test('2D along axis 0', () {
+      // [[3,1,4],[1,5,9]]
+      // Along axis 0: argmin([3,1])=1, argmin([1,5])=0, argmin([4,9])=0
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final result = tensor.argminAxis(0);
+      expect(result.shape, equals([3]));
+      expect(result.toList(), equals([1, 0, 0]));
+    });
+
+    test('2D along axis 1', () {
+      // [[3,1,4],[1,5,9]]
+      // Along axis 1: argmin([3,1,4])=1, argmin([1,5,9])=0
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final result = tensor.argminAxis(1);
+      expect(result.shape, equals([2]));
+      expect(result.toList(), equals([1, 0]));
+    });
+
+    test('keepDims: true', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final result = tensor.argminAxis(0, keepDims: true);
+      expect(result.shape, equals([1, 3]));
+      expect(result.toList(), equals([1, 0, 0]));
+    });
+
+    test('negative axis', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final result = tensor.argminAxis(-2);
+      expect(result.shape, equals([3]));
+      expect(result.toList(), equals([1, 0, 0]));
+    });
+
+    test('output dtype is int64', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 2, 3]),
+        [3],
+      );
+      final result = tensor.argminAxis(0);
+      expect(result.dtype, equals(DType.int64));
+    });
+
+    test('non-contiguous (transposed) tensor', () {
+      // Original [2,3]: [[6,5,4],[3,2,1]]
+      // Transposed [3,2]: [[6,3],[5,2],[4,1]]
+      // argminAxis(0): argmin([6,5,4])=2, argmin([3,2,1])=2
+      // Wait, axis 0 of transposed [3,2]: argmin([6,3])=1, argmin([5,2])=1, argmin([4,1])=1
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([6, 5, 4, 3, 2, 1]),
+        [2, 3],
+      );
+      final transposed = tensor.transpose([1, 0]);
+      final result = transposed.argminAxis(0);
+      expect(result.shape, equals([2]));
+      expect(result.toList(), equals([2, 2]));
+    });
+  });
+
+  group('ArgMaxOp', () {
+    test('apply returns correct result', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final op = ArgMaxOp(axis: 1);
+      final result = op.apply(tensor);
+      expect(result.shape, equals([2]));
+      expect(result.toList(), equals([2, 2]));
+      expect(result.dtype, equals(DType.int64));
+    });
+
+    test('apply with keepDims', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final op = ArgMaxOp(axis: 1, keepDims: true);
+      final result = op.apply(tensor);
+      expect(result.shape, equals([2, 1]));
+    });
+
+    test('computeOutputShape', () {
+      final op = ArgMaxOp(axis: 1);
+      expect(op.computeOutputShape([2, 3, 4]), equals([2, 4]));
+    });
+
+    test('computeOutputShape with keepDims', () {
+      final op = ArgMaxOp(axis: 1, keepDims: true);
+      expect(op.computeOutputShape([2, 3, 4]), equals([2, 1, 4]));
+    });
+
+    test('computeOutputShape with negative axis', () {
+      final op = ArgMaxOp(axis: -1);
+      expect(op.computeOutputShape([2, 3, 4]), equals([2, 3]));
+    });
+
+    test('computeOutputShape 1D', () {
+      final op = ArgMaxOp(axis: 0);
+      expect(op.computeOutputShape([5]), equals([1]));
+    });
+
+    test('capabilities', () {
+      final op = ArgMaxOp(axis: 0);
+      expect(op.capabilities.preservesShape, isFalse);
+      expect(op.capabilities.modifiesDType, isTrue);
+      expect(op.capabilities.onnxOpType, equals('ArgMax'));
+      expect(op.capabilities.pytorchEquivalent, equals('torch.argmax'));
+    });
+
+    test('name', () {
+      final op = ArgMaxOp(axis: 0);
+      expect(op.name, equals('ArgMax'));
+    });
+
+    test('call alias works', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([1, 3, 2]),
+        [3],
+      );
+      final op = ArgMaxOp(axis: 0);
+      final result = op.call(tensor);
+      expect(result.toList(), equals([1]));
+    });
+
+    test('invalid axis throws', () {
+      final op = ArgMaxOp(axis: 3);
+      expect(
+        () => op.computeOutputShape([2, 3]),
+        throwsA(isA<IndexOutOfBoundsException>()),
+      );
+    });
+  });
+
+  group('ArgMinOp', () {
+    test('apply returns correct result', () {
+      final tensor = TensorBuffer.fromFloat32List(
+        Float32List.fromList([3, 1, 4, 1, 5, 9]),
+        [2, 3],
+      );
+      final op = ArgMinOp(axis: 1);
+      final result = op.apply(tensor);
+      expect(result.shape, equals([2]));
+      expect(result.toList(), equals([1, 0]));
+      expect(result.dtype, equals(DType.int64));
+    });
+
+    test('capabilities', () {
+      final op = ArgMinOp(axis: 0);
+      expect(op.capabilities.preservesShape, isFalse);
+      expect(op.capabilities.modifiesDType, isTrue);
+      expect(op.capabilities.onnxOpType, equals('ArgMin'));
+      expect(op.capabilities.pytorchEquivalent, equals('torch.argmin'));
+    });
+
+    test('name', () {
+      final op = ArgMinOp(axis: 0);
+      expect(op.name, equals('ArgMin'));
+    });
+
+    test('computeOutputShape', () {
+      final op = ArgMinOp(axis: 0);
+      expect(op.computeOutputShape([2, 3, 4]), equals([3, 4]));
+    });
+  });
+}

--- a/test/argmax_argmin_test.dart
+++ b/test/argmax_argmin_test.dart
@@ -30,10 +30,9 @@ void main() {
     });
 
     test('single element', () {
-      final tensor = TensorBuffer.fromFloat32List(
-        Float32List.fromList([42]),
-        [1],
-      );
+      final tensor = TensorBuffer.fromFloat32List(Float32List.fromList([42]), [
+        1,
+      ]);
       expect(tensor.argmax(), equals(0));
     });
 
@@ -85,10 +84,9 @@ void main() {
     });
 
     test('single element', () {
-      final tensor = TensorBuffer.fromFloat32List(
-        Float32List.fromList([42]),
-        [1],
-      );
+      final tensor = TensorBuffer.fromFloat32List(Float32List.fromList([42]), [
+        1,
+      ]);
       expect(tensor.argmin(), equals(0));
     });
 


### PR DESCRIPTION
## Summary
This PR adds argmax and argmin operations to the tensor preprocessing library, enabling users to find indices of maximum and minimum values both globally and along specific axes.

## Key Changes

- **Global index reduction methods** (`argmax()`, `argmin()`):
  - Added to `TensorBufferReduce` extension
  - Return flat indices of max/min values in row-major order
  - Handle non-contiguous tensors correctly

- **Axis-wise index reduction methods** (`argmaxAxis()`, `argminAxis()`):
  - Added to `TensorBufferReduce` extension
  - Support negative axis indexing
  - Support `keepDims` parameter to retain reduced dimension
  - Always output `DType.int64` regardless of input dtype
  - Implemented via new `_reduceAxisToIndex()` helper method

- **TransformOp implementations**:
  - `ArgMaxOp` and `ArgMinOp` classes in new `argmax_op.dart`
  - Proper shape computation with negative axis support
  - ONNX and PyTorch equivalence metadata
  - Full integration with operation capabilities system

- **Helper functions**:
  - `_argmaxReduce()` and `_argminReduce()` for value-to-index conversion
  - Generic `_reduceAxisToIndex()` for flexible axis reduction

- **Comprehensive test coverage** (420 lines):
  - Global argmax/argmin with various tensor shapes
  - Axis-wise operations with 2D and 3D tensors
  - Edge cases: single elements, duplicate extrema, negative values
  - Non-contiguous (transposed) tensor handling
  - `keepDims` and negative axis behavior
  - Operation class functionality and shape computation
  - Error handling for invalid axes

## Implementation Details

- Index reduction properly handles multi-dimensional indexing with strides
- Output shape computation correctly handles `keepDims` and scalar results
- All operations respect tensor storage layout (non-contiguous tensors)
- Consistent with existing reduction operation patterns in the codebase

https://claude.ai/code/session_017tVYh6njyMCck4fz5tP2vw