### PR TITLE
docs: update documentation for v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-05
+
+### Added
+
+- **`ArgMaxOp` / `ArgMinOp`** - Argmax/argmin index reduction operations (Issue #34, PR #62):
+  - `argmax()` / `argmin()` global methods returning flat index (`int`)
+  - `argmaxAxis()` / `argminAxis()` axis reduction returning `TensorBuffer` with `DType.int64`
+  - `ArgMaxOp` / `ArgMinOp` TransformOp subclasses with ONNX metadata (opset 13)
+  - Supports `keepDims` parameter and negative axis indexing
+  - Handles non-contiguous tensors via stride-based access
+  - Equivalent to `torch.argmax()` / `torch.argmin()` in PyTorch and ONNX `ArgMax` / `ArgMin` operators
+
 ## [0.8.5] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Tensor preprocessing library for Flutter/Dart. NumPy-like transforms pipeline fo
 
 ```yaml
 dependencies:
-  dart_tensor_preprocessing: ^0.8.5
+  dart_tensor_preprocessing: ^0.9.0
 ```
 
 ## Quick Start
@@ -153,6 +153,7 @@ final result = await pipeline.runAsync(input, isolateThreshold: 50000);
 - `MaskedFillOp` - Fill tensor positions where mask is true
 - `GatherOp` - Gather elements along a dimension by index
 - `TopKOp` - Select k largest/smallest values and indices along an axis (quickselect)
+- `ArgMaxOp` / `ArgMinOp` - Index of max/min value along an axis (ONNX ArgMax/ArgMin opset 13)
 - `TileOp` - Tile/repeat tensor contents
 - `RepeatOp` - Repeat tensor (PyTorch `.repeat()` semantics)
 - `RollOp` - Circular shift along dimensions
@@ -351,6 +352,8 @@ This library is designed to produce identical results to PyTorch/torchvision ope
 | `MaskedFillOp` | `Tensor.masked_fill_()` |
 | `GatherOp` | `torch.gather()` |
 | `TopKOp` / `tensor.topk()` | `torch.topk()` |
+| `tensor.argmax()` / `tensor.argmin()` | `tensor.argmax()` / `tensor.argmin()` |
+| `ArgMaxOp` / `ArgMinOp` | `torch.argmax()` / `torch.argmin()` |
 | `split()` / `chunk()` | `torch.split()` / `torch.chunk()` |
 | `TileOp` | `Tensor.repeat()` / ONNX `Tile` |
 | `RepeatOp` | `Tensor.repeat()` |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_tensor_preprocessing
 description: >-
   High-performance tensor preprocessing library for Flutter/Dart.
   NumPy-like transforms pipeline for ONNX Runtime inference.
-version: 0.8.5
+version: 0.9.0
 repository: https://github.com/brody-0125/dart_tensor_preprocessing
 homepage: https://github.com/brody-0125/dart_tensor_preprocessing
 


### PR DESCRIPTION
## Summary

- Bump version to `0.9.0` in `pubspec.yaml`
- Add `[0.9.0] - 2026-04-05` CHANGELOG entry for argmax/argmin operations (Issue #34, PR #62)
- Update README: installation version `^0.9.0`, add `ArgMaxOp`/`ArgMinOp` to Available Operations and PyTorch Compatibility table

## Test plan

- [ ] Verify CHANGELOG format matches existing entries
- [ ] Verify README installation version is `^0.9.0`
- [ ] Verify `ArgMaxOp`/`ArgMinOp` listed in Tensor Manipulation and PyTorch Compatibility sections
- [ ] `dart analyze` passes
- [ ] `dart test` passes

https://claude.ai/code/session_0135as4GSaWTZfQuWhgv9zHB